### PR TITLE
Changes to search record print methods

### DIFF
--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -249,10 +249,20 @@ print.bcdc_recordlist <- function(x, ...) {
   if (n_print < len) cat(" (Showing the top 10)")
   cat("\nTitles:\n")
   x <- purrr::set_names(x, NULL)
-  cat(paste(purrr::imap(x[1:n_print], ~ {
-    paste0(.y, ": ", .x[["title"]], "\n ID: ",
-           .x[["id"]], "\n NAME: ", .x[["name"]])
-  }), collapse = "\n"), "\n")
+cat(paste(purrr::imap(x[1:n_print], ~ {
+  paste0(
+    .y, ": ",
+    purrr::pluck(.x, "title"),
+    " (",
+    paste0(
+      unique(map_chr(purrr::pluck(.x, "resources"), purrr::pluck, "format")),
+      collapse = ","
+    ),
+    ")",
+    "\n ID: ", purrr::pluck(.x, "id"),
+    "\n NAME: ", purrr::pluck(.x, "name")
+  )
+}), collapse = "\n"), "\n")
   cat("\nAccess a single record by calling bcdc_get_record(ID)
 with the ID from the desired record.")
 }

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -229,12 +229,12 @@ print.bcdc_record <- function(x, ...) {
   for (i in seq_along(x$resources)) {
     r <- x$resources[[i]]
     cat("  ", i, ": ", r$name, "\n", sep = "")
-    #cat("    description:", r$description, "\n")
-    if(r$format == "wms"){
-      cat("    id:", r$package_id, "\n")
-    } else {
-      cat("    id:", r$id, "\n")
-    }
+    cat("    description:", r$description, "\n")
+    # if(r$format == "wms"){
+    #   cat("    id:", r$package_id, "\n")
+    # } else {
+    #   cat("    id:", r$id, "\n")
+    # }
     cat("    format:", r$format, "\n")
     cat("    access:", r$resource_storage_access_method, "\n")
     #cat("    access_url:", r$url, "\n")

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -223,16 +223,16 @@ print.bcdc_record <- function(x, ...) {
   cat("\nSector:", x$sector)
   cat("\nLicence:", x$license_title)
   cat("\nType:", x$type, "\n")
-  cat("\nDescription:\n    ", x$notes, "\n")
+  #cat("\nDescription:\n    ", x$notes, "\n")
   cat("\nResources: (", length(x$resources), ")\n")
   for (i in seq_along(x$resources)) {
     r <- x$resources[[i]]
     cat("  ", i, ": ", r$name, "\n", sep = "")
-    cat("    description:", r$description, "\n")
+    #cat("    description:", r$description, "\n")
     cat("    id:", r$id, "\n")
     cat("    format:", r$format, "\n")
     cat("    access:", r$resource_storage_access_method, "\n")
-    cat("    access_url:", r$url, "\n")
+    #cat("    access_url:", r$url, "\n")
   }
 }
 
@@ -247,7 +247,7 @@ print.bcdc_recordlist <- function(x, ...) {
   x <- purrr::set_names(x, NULL)
   cat(paste(purrr::imap(x[1:n_print], ~ {
     paste0(.y, ": ", .x[["title"]], "\n ID: ",
-           .x[["id"]])
+           .x[["id"]], "\n NAME: ", .x[["name"]])
   }), collapse = "\n"), "\n")
   cat("\nAccess a single record by calling bcdc_get_record(ID)
 with the ID from the desired record.")

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -255,7 +255,7 @@ cat(paste(purrr::imap(x[1:n_print], ~ {
     purrr::pluck(.x, "title"),
     " (",
     paste0(
-      unique(map_chr(purrr::pluck(.x, "resources"), purrr::pluck, "format")),
+      unique(purrr::map_chr(purrr::pluck(.x, "resources"), purrr::pluck, "format")),
       collapse = ","
     ),
     ")",

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -229,7 +229,11 @@ print.bcdc_record <- function(x, ...) {
     r <- x$resources[[i]]
     cat("  ", i, ": ", r$name, "\n", sep = "")
     #cat("    description:", r$description, "\n")
-    cat("    id:", r$id, "\n")
+    if(r$format == "wms"){
+      cat("    id:", r$package_id, "\n")
+    } else {
+      cat("    id:", r$id, "\n")
+    }
     cat("    format:", r$format, "\n")
     cat("    access:", r$resource_storage_access_method, "\n")
     #cat("    access_url:", r$url, "\n")

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -223,7 +223,8 @@ print.bcdc_record <- function(x, ...) {
   cat("\nSector:", x$sector)
   cat("\nLicence:", x$license_title)
   cat("\nType:", x$type, "\n")
-  #cat("\nDescription:\n    ", x$notes, "\n")
+  cat("\nDescription:\n")
+  cat(paste0("    ", strwrap(x$notes, width = 85), collapse = "\n"), "\n")
   cat("\nResources: (", length(x$resources), ")\n")
   for (i in seq_along(x$resources)) {
     r <- x$resources[[i]]


### PR DESCRIPTION
## Change to bcdc_search
- Add english name string
- Add type of formats available

###  From
``` r
library(bcdata)

bcdc_search("snow")
#> List of B.C. Data Catalogue Records
#> 
#> Number of records: 28 (Showing the top 10)
#> Titles:
#> 1: Indicator Summary Data: Change in Snow Depth and Snow Water Content in BC (1950-2014)
#>  ID: 86526746-40dd-41d2-82c0-fbee3a2e93a2
#> 2: Automated Snow Weather Station Locations
#>  ID: ebe546aa-ac34-491c-a828-fdc87fb70610
#> 3: Archive Automated Snow Weather Station Data
#>  ID: 5e7acd31-b242-4f09-8a64-000af872d68f
#> 4: Current Season Manual Snow Survey Data
#>  ID: 12472805-6f6d-457b-8db2-5c1f42a00099
#> 5: Manual Snow Survey Locations
#>  ID: 9f653102-5627-45a7-bd4c-686e365ee04a
#> 6: Archive Manual Snow Survey Data
#>  ID: 705df46f-e9d6-4124-bc4a-66f54c07b228
#> 7: Current Season Automated Snow Weather Station Data
#>  ID: 3a34bdd1-61b2-4687-8b55-c5db5e13ff50
#> 8: Snow Survey Administrative Basin Areas
#>  ID: 9ec01cdb-7085-44fe-b059-9fe5aefb7497
#> 9: Climate indicators for BC Census Subdivisions
#>  ID: daad930e-aa29-4ac9-90c8-c4c4a3d487b7
#> 10: Other Land Cover 1:250,000 GeoBase Land Cover
#>  ID: 2ef0be2a-2cfc-4ef1-b203-2875fd7023a8 
#> 
#> Access a single record by calling bcdc_get_record(ID)
#> with the ID from the desired record.
```

<sup>Created on 2019-02-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

### To
``` r
library(bcdata)

bcdc_search("snow")
#> List of B.C. Data Catalogue Records
#> 
#> Number of records: 28 (Showing the top 10)
#> Titles:
#> 1: Indicator Summary Data: Change in Snow Depth and Snow Water Content in BC (1950-2014) (csv)
#>  ID: 86526746-40dd-41d2-82c0-fbee3a2e93a2
#>  NAME: indicator-summary-data-change-in-snow-depth-and-snow-water-content-in-bc-1950-2014-
#> 2: Automated Snow Weather Station Locations (wms,kml,other)
#>  ID: ebe546aa-ac34-491c-a828-fdc87fb70610
#>  NAME: automated-snow-weather-station-locations
#> 3: Archive Automated Snow Weather Station Data (csv)
#>  ID: 5e7acd31-b242-4f09-8a64-000af872d68f
#>  NAME: archive-automated-snow-weather-station-data
#> 4: Current Season Manual Snow Survey Data (csv)
#>  ID: 12472805-6f6d-457b-8db2-5c1f42a00099
#>  NAME: current-season-manual-snow-survey-data
#> 5: Manual Snow Survey Locations (wms,kml,other)
#>  ID: 9f653102-5627-45a7-bd4c-686e365ee04a
#>  NAME: manual-snow-survey-locations
#> 6: Archive Manual Snow Survey Data (csv)
#>  ID: 705df46f-e9d6-4124-bc4a-66f54c07b228
#>  NAME: archive-manual-snow-survey-data
#> 7: Current Season Automated Snow Weather Station Data (csv)
#>  ID: 3a34bdd1-61b2-4687-8b55-c5db5e13ff50
#>  NAME: current-season-automated-snow-weather-station-data
#> 8: Snow Survey Administrative Basin Areas (other,wms,kml)
#>  ID: 9ec01cdb-7085-44fe-b059-9fe5aefb7497
#>  NAME: snow-survey-administrative-basin-areas
#> 9: Climate indicators for BC Census Subdivisions (other)
#>  ID: daad930e-aa29-4ac9-90c8-c4c4a3d487b7
#>  NAME: climate-indicators-for-bc-census-subdivisions
#> 10: Other Land Cover 1:250,000 GeoBase Land Cover (other)
#>  ID: 2ef0be2a-2cfc-4ef1-b203-2875fd7023a8
#>  NAME: other-land-cover-1-250-000-geobase-land-cover 
#> 
#> Access a single record by calling bcdc_get_record(ID)
#> with the ID from the desired record.
```

<sup>Created on 2019-02-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>


## Change to bcdc_get_record
- Remove descriptions. My thinking here is that the console is not the place for detailed description of the object. That could happen with `bcdc_browse('ebe546aa-ac34-491c-a828-fdc87fb70610')`.
- The wms id generated with bcdc_get_record is not the id required to access the data. Rather it is the resource id (`package_id` in the object returned). I've changed it so that the id returned by `bcdc_get_record` that is listed in the wms entry actually works to return spatial data. 

### From
``` r
library(bcdata)

bcdc_get_record("ebe546aa-ac34-491c-a828-fdc87fb70610")
#> B.C. Data Catalogue Record:
#>     Automated Snow Weather Station Locations 
#> 
#> Name: automated-snow-weather-station-locations (ID: ebe546aa-ac34-491c-a828-fdc87fb70610 )
#> Permalink: https://catalogue.data.gov.bc.ca/dataset/ebe546aa-ac34-491c-a828-fdc87fb70610
#> Sector: Natural Resources
#> Licence: Open Government Licence - British Columbia
#> Type: Geographic 
#> 
#> Description:
#>      Locations of automated snow weather stations, active and inactive. Automated snow weather stations are components of the BC snow survey network.   
#> 
#> Resources: ( 3 )
#>   1: WMS getCapabilities request
#>     description: For use in viewers such as ESRI tools  
#> 
#>  [Click here for information on how to connect](http://www2.gov.bc.ca/gov/content/data/geographic-data-services/web-based-mapping/map-services) 
#>     id: d54a8a1c-a479-4637-a1d2-60663fd446f5 
#>     format: wms 
#>     access: Service 
#>     access_url: https://openmaps.gov.bc.ca/geo/pub/WHSE_WATER_MANAGEMENT.SSL_SNOW_ASWS_STNS_SP/ows?service=WMS&request=GetCapabilities 
#>   2: KML Network Link
#>     description: For use in viewers such as Google Earth  
#> 
#>  [Click here for information on how to connect](http://www2.gov.bc.ca/gov/content/data/geographic-data-services/web-based-mapping/map-services) 
#>     id: c77c8c82-bf2e-43cb-adae-e9ab3572b89c 
#>     format: kml 
#>     access: Service 
#>     access_url: https://openmaps.gov.bc.ca/kml/geo/layers/WHSE_WATER_MANAGEMENT.SSL_SNOW_ASWS_STNS_SP_loader.kml 
#>   3: BC Geographic Warehouse Custom Download
#>     description:  
#>     id: e2f66975-ee49-4b66-ab0b-822c7c49e635 
#>     format: other 
#>     access: Indirect Access 
#>     access_url: https://catalogue.data.gov.bc.ca/api/ofi/other/WHSE_WATER_MANAGEMENT.SSL_SNOW_ASWS_STNS_SP
```

<sup>Created on 2019-02-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

### To
``` r
library(bcdata)

bcdc_get_record("ebe546aa-ac34-491c-a828-fdc87fb70610")
#> B.C. Data Catalogue Record:
#>     Automated Snow Weather Station Locations 
#> 
#> Name: automated-snow-weather-station-locations (ID: ebe546aa-ac34-491c-a828-fdc87fb70610 )
#> Permalink: https://catalogue.data.gov.bc.ca/dataset/ebe546aa-ac34-491c-a828-fdc87fb70610
#> Sector: Natural Resources
#> Licence: Open Government Licence - British Columbia
#> Type: Geographic 
#> 
#> Resources: ( 3 )
#>   1: WMS getCapabilities request
#>     id: ebe546aa-ac34-491c-a828-fdc87fb70610 
#>     format: wms 
#>     access: Service 
#>   2: KML Network Link
#>     id: c77c8c82-bf2e-43cb-adae-e9ab3572b89c 
#>     format: kml 
#>     access: Service 
#>   3: BC Geographic Warehouse Custom Download
#>     id: e2f66975-ee49-4b66-ab0b-822c7c49e635 
#>     format: other 
#>     access: Indirect Access
```

<sup>Created on 2019-02-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
