### PR TITLE
Allow partial evaluation so objects can be passed to filter statements.

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -131,7 +131,8 @@ print.bcdc_recordlist <- function(x, ...) {
 #' @export
 filter.bcdc_promise <- function(.data, ...) {
 
-  .data$query_list$CQL_FILTER <- cql_translate(...)
+  dots <- rlang::quos(...)
+  .data$query_list$CQL_FILTER <- cql_translate(dots)
 
   ## Change CQL query on the fly if geom is not GEOMETRY
   .data$query_list$CQL_FILTER <- specify_geom_name(.data$obj, .data$query_list)


### PR DESCRIPTION
Hopefully addresses #46, and also may address #30
Likely requires cleanup of messy evaluation of cql expressions and spatial predicates.