### PR TITLE
Warn once when user uses human-readable id rather than permament id

### DIFF
--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -167,6 +167,13 @@ bcdc_search <- function(..., license_id = NULL,
 #' @param id the human-readable name, permalink id, or
 #' url of the record.
 #'
+#' It is advised to use the permament id for a record rather than the
+#' human-readable name to guard against future name changes of the record.
+#' If you use the human-readble name a warning will be issued once per
+#' session. You can silence these warnings altogether by setting an option:
+#' `options("silence_named_get_record_warning" = TRUE)` - which you can put
+#' in your .Rprofile file so the option persists across sessions.
+#'
 #' @return A list containing the metadata for the record
 #' @export
 #'
@@ -193,6 +200,14 @@ bcdc_get_record <- function(id) {
   stopifnot(res$success)
 
   ret <- res$result
+
+  if (ret$id != id) {
+    get_record_warn_once(
+      "It is advised to use the permanent id ('", ret$id, "') ",
+      "rather than the name of the record ('", id,
+      "')to guard against future changes"
+    )
+  }
 
   as.bcdc_record(ret)
 }

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -205,7 +205,7 @@ bcdc_get_record <- function(id) {
     get_record_warn_once(
       "It is advised to use the permanent id ('", ret$id, "') ",
       "rather than the name of the record ('", id,
-      "')to guard against future changes"
+      "') to guard against future name changes"
     )
   }
 

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -12,9 +12,16 @@
 
 #' Download and read a dataset from a B.C. Data Catalogue resource
 #'
-#'
 #' @param x either a `bcdc_record` object (from the result of `bcdc_get_record()`)
 #' or a character string denoting the id of a resource (or the url).
+#'
+#' It is advised to use the permament id for a record rather than the
+#' human-readable name to guard against future name changes of the record.
+#' If you use the human-readble name a warning will be issued once per
+#' session. You can silence these warnings altogether by setting an option:
+#' `options("silence_named_get_data_warning" = TRUE)` - which you can set
+#' in your .Rprofile file so the option persists across sessions.
+#'
 #' @param format Defaults to NULL which will first check to see if the record is a WMS/WFS record.
 #' If so an sf object is returned. Otherwise a format needs to be specified. `bcdc_get_record` can
 #' be used to identify which formats are available.

--- a/R/utils.R
+++ b/R/utils.R
@@ -176,10 +176,12 @@ gml_types <- function(x) {
   )
 }
 
-warn_once <- function(msg) {
-  if (!get("warned", envir = bcdata_env)) {
-    warning(msg)
-    assign("warned", TRUE, envir = bcdata_env)
+get_record_warn_once <- function(...) {
+  silence <- isTRUE(getOption("silence_named_get_record_warning"))
+  warned <- bcdata_env$named_get_record_warned
+  if (!silence && !warned) {
+    warning(..., call. = FALSE)
+    assign("named_get_record_warned", TRUE, envir = bcdata_env)
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -175,3 +175,11 @@ gml_types <- function(x) {
     "gml:MultiGeometryPropertyType"
   )
 }
+
+warn_once <- function(msg) {
+  if (!get("warned", envir = bcdata_env)) {
+    warning(msg)
+    assign("warned", TRUE, envir = bcdata_env)
+  }
+}
+

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,17 @@
+# Copyright 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+bcdata_env <- new.env(parent = emptyenv())
+
+.onLoad <- function(...) {
+ assign("warned", FALSE, envir = bcdata_env)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,5 +13,5 @@
 bcdata_env <- new.env(parent = emptyenv())
 
 .onLoad <- function(...) {
- assign("warned", FALSE, envir = bcdata_env)
+ assign("named_get_record_warned", FALSE, envir = bcdata_env)
 }

--- a/man/bcdc_describe_feature.Rd
+++ b/man/bcdc_describe_feature.Rd
@@ -8,7 +8,14 @@ bcdc_describe_feature(x = NULL)
 }
 \arguments{
 \item{x}{either a \code{bcdc_record} object (from the result of \code{bcdc_get_record()})
-or a character string denoting the id of a resource (or the url).}
+or a character string denoting the id of a resource (or the url).
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_data_warning" = TRUE)} - which you can set
+in your .Rprofile file so the option persists across sessions.}
 }
 \description{
 Describe the columns from a WFS feature. The column name, whether a column can be

--- a/man/bcdc_get_data.Rd
+++ b/man/bcdc_get_data.Rd
@@ -8,7 +8,14 @@ bcdc_get_data(x, format = NULL, resource = NULL, ...)
 }
 \arguments{
 \item{x}{either a \code{bcdc_record} object (from the result of \code{bcdc_get_record()})
-or a character string denoting the id of a resource (or the url).}
+or a character string denoting the id of a resource (or the url).
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_data_warning" = TRUE)} - which you can set
+in your .Rprofile file so the option persists across sessions.}
 
 \item{format}{Defaults to NULL which will first check to see if the record is a WMS/WFS record.
 If so an sf object is returned. Otherwise a format needs to be specified. \code{bcdc_get_record} can

--- a/man/bcdc_get_geodata.Rd
+++ b/man/bcdc_get_geodata.Rd
@@ -8,7 +8,14 @@ bcdc_get_geodata(x = NULL, crs = 3005)
 }
 \arguments{
 \item{x}{either a \code{bcdc_record} object (from the result of \code{bcdc_get_record()})
-or a character string denoting the id of a resource (or the url).}
+or a character string denoting the id of a resource (or the url).
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_data_warning" = TRUE)} - which you can set
+in your .Rprofile file so the option persists across sessions.}
 
 \item{crs}{the epsg code for the coordinate reference system. Defaults to \code{3005}
 (B.C. Albers). See https://epsgi.io.}

--- a/man/bcdc_get_record.Rd
+++ b/man/bcdc_get_record.Rd
@@ -8,7 +8,14 @@ bcdc_get_record(id)
 }
 \arguments{
 \item{id}{the human-readable name, permalink id, or
-url of the record.}
+url of the record.
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_record_warning" = TRUE)} - which you can put
+in your .Rprofile file so the option persists across sessions.}
 }
 \value{
 A list containing the metadata for the record

--- a/man/bcdc_preview.Rd
+++ b/man/bcdc_preview.Rd
@@ -8,7 +8,14 @@ bcdc_preview(x = NULL)
 }
 \arguments{
 \item{x}{either a \code{bcdc_record} object (from the result of \code{bcdc_get_record()})
-or a character string denoting the id of a resource (or the url).}
+or a character string denoting the id of a resource (or the url).
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_data_warning" = TRUE)} - which you can set
+in your .Rprofile file so the option persists across sessions.}
 }
 \description{
 Get map from the B.C. Web Mapping Service

--- a/man/bcdc_query_geodata.Rd
+++ b/man/bcdc_query_geodata.Rd
@@ -8,7 +8,14 @@ bcdc_query_geodata(x = NULL, crs = 3005)
 }
 \arguments{
 \item{x}{either a \code{bcdc_record} object (from the result of \code{bcdc_get_record()})
-or a character string denoting the id of a resource (or the url).}
+or a character string denoting the id of a resource (or the url).
+
+It is advised to use the permament id for a record rather than the
+human-readable name to guard against future name changes of the record.
+If you use the human-readble name a warning will be issued once per
+session. You can silence these warnings altogether by setting an option:
+\code{options("silence_named_get_data_warning" = TRUE)} - which you can set
+in your .Rprofile file so the option persists across sessions.}
 
 \item{crs}{the epsg code for the coordinate reference system. Defaults to \code{3005}
 (B.C. Albers). See https://epsgi.io.}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,1 @@
+old_silence_get_record <- options("silence_named_get_record_warning" = TRUE)

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,0 +1,1 @@
+options("silence_named_get_record_warning" = old_silence_get_record)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -14,3 +14,10 @@ test_that("check_geom_col_names works", {
   new_query <- specify_geom_name(ap, query_list)
   expect_equal(new_query, "DWITHIN(SHAPE, foobar)")
 })
+
+test_that("get_record_warn_once warns once and only once", {
+  options("silence_named_get_record_warning" = FALSE)
+  expect_warning(get_record_warn_once("Hi"))
+  expect_silent(get_record_warn_once("Hi"))
+  options("silence_named_get_record_warning" = TRUE)
+})


### PR DESCRIPTION
I opted to trigger one warning per session regardless of the function called. This is called in `bcdc_get_record()` which is called by many other functions: `bcdc_get_data()`, bcdc_query_geodata()`, `bcdc_preview()`, and `bcdc_describe_feature()`. So a call to any of those functions will trigger the warning.

I also added the ability for a user to suppress these warnings entirely (very useful for us in tests) by setting: `options("silence_named_get_record_warning" = TRUE)`

``` r
library(bcdata)
#> 
#> Attaching package: 'bcdata'
#> The following object is masked from 'package:stats':
#> 
#>     filter

bcdc_get_record("bc-airports")
#> Warning: It is advised to use the permanent id ('76b1b7a3-2112-4444-857a-
#> afccf7b20da8') rather than the name of the record ('bc-airports') to guard
#> against future name changes
#> B.C. Data Catalogue Record:
#>     BC Airports 
#> 
#> Name: bc-airports (ID: 76b1b7a3-2112-4444-857a-afccf7b20da8 )
#> Permalink: https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8
#> Sector: Natural Resources
#> Licence: Open Government Licence - British Columbia
#> Type: Geographic 
#> 
#> Description:
#>     BC Airports identifies locations where aircraft may take-off and land. No guarantee
#>     is given that an identified point will be maintained to sufficient standards for
#>     landing and take-off of any/all aircraft.  It includes airports, aerodromes, water
#>     aerodromes, heliports, and airstrips. 
#> 
#> Resources: ( 2 )
#>   BC_Airports_Attribute_Values
#>     format: xlsx 
#>     url: https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8/resource/fcccba36-b528-4731-8978-940b3cc04f69/download/wilmbvicgeobccriticalinfrastructuredocumentsbcairportsattributevalues.xlsx 
#>     resource: fcccba36-b528-4731-8978-940b3cc04f69 
#>     access: Direct Access 
#>     code: bcdc_get_data(x = '76b1b7a3-2112-4444-857a-afccf7b20da8',
#>         format = 'xlsx', resource = 'fcccba36-b528-4731-8978-940b3cc04f69')
#>   WMS getCapabilities request
#>     format: wms 
#>     resource: 4d0377d9-e8a1-429b-824f-0ce8f363512c 
#>     access: Service 
#>     code: bcdc_get_data(x = '76b1b7a3-2112-4444-857a-afccf7b20da8')
```

<sup>Created on 2019-05-02 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>