### PR TITLE
check for the length of the CQL_FILTER parameter and fail if too long

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -141,6 +141,13 @@ filter.bcdc_promise <- function(.data, ...) {
   ## Change CQL query on the fly if geom is not GEOMETRY
   .data$query_list$CQL_FILTER <- specify_geom_name(.data$obj, .data$query_list)
 
+  if(!safe_request_length(.data$query_list)){
+    stop("The vector you are trying to filter by is too long. Consider either breaking
+    up the request into two or more bcdc_query_geodata() calls or using a spatial
+    operator to spatial define your request. See ?cql_geom_predicates.",
+    call. = FALSE)
+  }
+
   as.bcdc_promise(list(query_list = .data$query_list, cli = .data$cli, obj = .data$obj))
 }
 
@@ -203,6 +210,7 @@ select.bcdc_promise <- function(.data, ...){
 collect.bcdc_promise <- function(x, ...){
 
   query_list <- x$query_list
+  safe_request_length(query_list)
   cli <- x$cli
 
   ## Determine total number of records for pagination purposes

--- a/R/utils.R
+++ b/R/utils.R
@@ -189,3 +189,14 @@ get_record_warn_once <- function(...) {
   }
 }
 
+safe_request_length <- function(query_list){
+  ## A conservative number of characters in the filter call.
+  ## Calculating from the query_list BEFORE the call actually happen.
+
+  ## Tested wfs url character limit
+  limits <- 5000
+  request_length <- nchar(query_list$CQL_FILTER)
+
+  return(request_length <= limits)
+}
+

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -110,3 +110,14 @@ test_that("subsetting works locally", {
   expect_equal(as.character(cql_translate(foo == y$id[2])),
                "(\"foo\" = 'b')")
 })
+
+test_that("large vectors supplied to filter fail with an error",{
+
+  pori <- bcdc_query_geodata("freshwater-atlas-stream-network") %>%
+    filter(WATERSHED_GROUP_CODE %in% "PORI") %>%
+    collect()
+
+  expect_error(bcdc_query_geodata("freshwater-atlas-stream-network") %>%
+    filter(WATERSHED_KEY %in% pori$WATERSHED_KEY[1:510]))
+
+})


### PR DESCRIPTION
I've gone with a conservative number for the length of the vector that is too long for wfs because we arrived at iteratively. This will fail when filtering since that is the only wfs parameter that would balloon big enough to cause a problem. 