### PR TITLE
Consolidate listing of file formats and associated 'read' functions

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -188,16 +188,12 @@ bcdc_get_data.character <- function(record, resource = NULL, ...) {
 #'
 
 bcdc_read_functions <- function(){
-  x <- formats_supported()
-
-  f <- dplyr::case_when(
-    x == "csv" ~ "readr::read_csv",
-    x == "kml" ~ "sf::read_sf",
-    x == "txt" ~ "readr::read_tsv",
-    x == "xlsx" ~ "readxl::read_excel",
-    x == "xls" ~ "readxl::read_excel",
-    TRUE ~ "No function defined"
+  dplyr::tribble(
+    ~format, ~package, ~fun,
+    "csv", "readr", "read_csv",
+    "kml", "sf", "read_sf",
+    "txt", "readr", "read_tsv",
+    "xlsx", "readxl", "read_xlsx",
+    "xls", "readxl", "read_xls"
   )
-
-  dplyr::tibble(format = x, `package::function` = f)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -217,7 +217,7 @@ read_from_url <- function(file_url, ...){
   cli <- bcdc_http_client(file_url)
 
   ## Establish where to download file
-  tmp <- tempfile(fileext = paste0(".", tools::file_ext(file_url)))
+  tmp <- tempfile(fileext = paste0(".", format))
   on.exit(unlink(tmp))
 
   r <- cli$get(disk = tmp)


### PR DESCRIPTION
Do not merge until #67 is ready to go. 

This might be a bit convoluted but I noticed that we were hard-coding supported file formats and their associated "read" functions in three places, which could cause headaches in the future - this consolidates them but at the cost of having slightly obscure code to actually get the function ready to read ([here](https://github.com/bcgov/bcdata/blob/f7c99d5544fdd376198560debf3eb905a5c2d3b5/R/utils.R#L226-L236))

We can either merge that first and then this, or merge this into `format_arg` branch and then the whole lot into master.
