### PR TITLE
Combine multiple filter statements

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -143,6 +143,7 @@ filter.bcdc_promise <- function(.data, ...) {
   ## Change CQL query on the fly if geom is not GEOMETRY
   current_cql = specify_geom_name(.data$obj, current_cql)
 
+  # Add cql filter statement to any existing cql filter statements
   .data$query_list$CQL_FILTER <- c(.data$query_list$CQL_FILTER, current_cql)
 
   if (!safe_request_length(.data$query_list)) {
@@ -324,6 +325,7 @@ show_query.bcdc_sf <- function(x, ...) {
 
 }
 
+# collapse vector of cql statements into one
 finalize_cql <- function(x, con = cql_dummy_con) {
   if (is.null(x)) return(NULL)
   dbplyr::sql_vector(x, collapse = " AND ", con = con)

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -143,8 +143,12 @@ filter.bcdc_promise <- function(.data, ...) {
   ## Change CQL query on the fly if geom is not GEOMETRY
   current_cql = specify_geom_name(.data$obj, current_cql)
 
-  # Add cql filter statement to any existing cql filter statements
-  .data$query_list$CQL_FILTER <- c(.data$query_list$CQL_FILTER, current_cql)
+  # Add cql filter statement to any existing cql filter statements.
+  # ensure .data$query_list$CQL_FILTER is class sql even if NULL, so
+  # dispatches on sql class and dbplyr::c.sql method is used
+  .data$query_list$CQL_FILTER <- c(dbplyr::sql(.data$query_list$CQL_FILTER),
+                                   current_cql,
+                                   drop_null = TRUE)
 
   if (!safe_request_length(.data$query_list)) {
     stop("The vector you are trying to filter by is too long. Consider either breaking

--- a/R/utils.R
+++ b/R/utils.R
@@ -202,7 +202,7 @@ safe_request_length <- function(query_list){
 
   ## Tested wfs url character limit
   limits <- 5000
-  request_length <- nchar(query_list$CQL_FILTER)
+  request_length <- nchar(finalize_cql(query_list$CQL_FILTER))
 
   return(request_length <= limits)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,6 +20,7 @@ compact <- function(l) Filter(Negate(is.null), l)
 
 
 bcdc_number_wfs_records <- function(query_list, client){
+
   query_list <- c(query_list, resultType = "hits")
 
   if(!is.null(query_list$propertyName)){
@@ -43,7 +44,7 @@ specify_geom_name <- function(record, CQL_statement){
   if (!any(dim(cols_df))) {
     warning("Unable to determine the name of the geometry column; assuming 'GEOMETRY'",
             call. = FALSE)
-    return(query_list)
+    return(CQL_statement)
   }
 
   # Find the geometry field and get the name of the field

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,13 +50,8 @@ specify_geom_name <- function(record, CQL_statement){
   # Find the geometry field and get the name of the field
   geom_col <- cols_df$column_name[cols_df$data_type == "SDO_GEOMETRY"]
 
-
-  glue::glue_sql(glue::glue(CQL_statement, geom_name = geom_col))
-  # if (geom_col != "GEOMETRY" && !is.null(query_list$CQL_FILTER)) {
-  #   query_list$CQL_FILTER = gsub("GEOMETRY", geom_col, query_list$CQL_FILTER)
-  # }
-
-
+  # substitute the geometry column name into the CQL statement and add sql class
+  dbplyr::sql(glue::glue(CQL_statement, geom_name = geom_col))
 }
 
 bcdc_read_sf <- function(x, ...){

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -139,8 +139,8 @@ test_that("multiple filter statements are additive",{
     filter(PHYSICAL_ADDRESS == "Victoria, BC") %>%
     filter(DESCRIPTION == "heliport")
 
-  expect_identical(show_query(heliports_one_line),
-                   show_query(heliports_two_line))
+  expect_identical(finalize_cql(heliports_one_line$query_list$CQL_FILTER),
+                   finalize_cql(heliports_two_line$query_list$CQL_FILTER))
 })
 
 test_that("multiple filter statements are additive with geometric operators",{

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -139,8 +139,8 @@ test_that("multiple filter statements are additive",{
     filter(PHYSICAL_ADDRESS == "Victoria, BC") %>%
     filter(DESCRIPTION == "heliport")
 
-  expect_identical(heliports_one_line[["query_list"]][["CQL_FILTER"]],
-                   heliports_two_line[["query_list"]][["CQL_FILTER"]])
+  expect_identical(show_query(heliports_one_line),
+                   show_query(heliports_two_line))
 })
 
 test_that("multiple filter statements are additive with geometric operators",{
@@ -156,5 +156,6 @@ test_that("multiple filter statements are additive with geometric operators",{
 
   cql_query <- "((\"ELMSD_REGION_BOUNDARY_NAME\" = 'Interior') AND (INTERSECTS(GEOMETRY, POLYGON ((956376 653960.8, 1397042 653960.8, 1397042 949343.3, 956376 949343.3, 956376 653960.8)))))"
 
-  expect_equal(em_program$query_list$CQL_FILTER@.Data, cql_query)
+  expect_equal(as.character(finalize_cql(em_program$query_list$CQL_FILTER)),
+               cql_query)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -13,7 +13,7 @@ test_that("check_geom_col_names works", {
   ap <- bcdc_get_record("bc-airports")
   new_query <- specify_geom_name(ap, query_list[["CQL_FILTER"]])
   expect_equal(as.character(new_query), "DWITHIN(SHAPE, foobar)")
-  expect_is(new_query, "SQL")
+  expect_is(new_query, "sql")
 })
 
 test_that("get_record_warn_once warns once and only once", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -12,7 +12,7 @@ test_that("check_geom_col_names works", {
 
   ap <- bcdc_get_record("bc-airports")
   new_query <- specify_geom_name(ap, query_list[["CQL_FILTER"]])
-  expect_equal(new_query@.Data, "DWITHIN(SHAPE, foobar)")
+  expect_equal(as.character(new_query), "DWITHIN(SHAPE, foobar)")
   expect_is(new_query, "SQL")
 })
 


### PR DESCRIPTION
This is a followup to #79, and closes #80. When successive `filter()` statements are called on a `bcdc_promise` object, they are stored as a vector of individual CQL filter statements. When required for execution (`show_query()`, `collect()`, `print.bcdc_promise()`) they are combined with `AND` using new function `finalize_cql()`