### PR TITLE
Implement post method

### DIFF
--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -57,7 +57,7 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
   # Only convert x to bbox if not using BBOX CQL function
   # because it doesn't take a geom
   if (!geometry_predicates == "BBOX") {
-    x <- sf_to_text_bbox(x)
+    x <- sf_union_to_text(x)
   }
 
   cql_args <-
@@ -86,14 +86,13 @@ cql_geom_predicate_list <- function() {
     "DWITHIN", "BEYOND", "BBOX")
 }
 
-sf_to_text_bbox <- function(x) {
+sf_union_to_text <- function(x) {
   if (!inherits(x, c("sf", "sfc", "sfg"))) {
     stop(paste(deparse(substitute(x)), "is not a valid sf object"),
          call. = FALSE)
   }
 
-  x = sf::st_bbox(x)
-  x = sf::st_as_sfc(x)
+  x = sf::st_union(x)
   sf::st_as_text(x)
 }
 

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -54,10 +54,11 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
 
   match.arg(geometry_predicates, cql_geom_predicate_list())
 
+
   # Only convert x to bbox if not using BBOX CQL function
   # because it doesn't take a geom
   if (!geometry_predicates == "BBOX") {
-    x <- sf_union_to_text(x)
+    x <- sf_text(x)
   }
 
   cql_args <-
@@ -86,13 +87,24 @@ cql_geom_predicate_list <- function() {
     "DWITHIN", "BEYOND", "BBOX")
 }
 
-sf_union_to_text <- function(x) {
+sf_text <- function(x) {
   if (!inherits(x, c("sf", "sfc", "sfg"))) {
     stop(paste(deparse(substitute(x)), "is not a valid sf object"),
          call. = FALSE)
   }
 
-  x = sf::st_union(x)
+  ## If too big here, drawing bounding
+  if(utils::object.size(x) > 5E5){
+    warning("The object is too large to perform exact spatial operations using bcdata.
+             To simplify the polygon, a bounding box was drawn around the polygon and all
+             features within the box will be returned. Options include further processing
+             with on the returned object or simplify the object.", call. = FALSE)
+    x = sf::st_bbox(x)
+    x = sf::st_as_sfc(x)
+  } else{
+    x = sf::st_union(x)
+  }
+
   sf::st_as_text(x)
 }
 

--- a/R/describe-feature.R
+++ b/R/describe-feature.R
@@ -44,7 +44,7 @@ bcdc_describe_feature <- function(record = NULL){
   ## GET and parse data to sf object
   cli <- bcdc_http_client(url = "https://openmaps.gov.bc.ca/geo/pub/wfs")
 
-  cc <- cli$get(query = query_list)
+  cc <- cli$post(body = query_list, encode = "form")
   status_failed <- cc$status_code >= 300
 
   xml_res <- xml2::read_xml(cc$parse("UTF-8"))

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -150,12 +150,12 @@ filter.bcdc_promise <- function(.data, ...) {
                                    current_cql,
                                    drop_null = TRUE)
 
-  if (!safe_request_length(.data$query_list)) {
-    stop("The vector you are trying to filter by is too long. Consider either breaking
-    up the request into two or more bcdc_query_geodata() calls or using a spatial
-    operator to spatial define your request. See ?cql_geom_predicates.",
-    call. = FALSE)
-  }
+  # if (!safe_request_length(.data$query_list)) {
+  #   stop("The vector you are trying to filter by is too long. Consider either breaking
+  #   up the request into two or more bcdc_query_geodata() calls or using a spatial
+  #   operator to spatial define your request. See ?cql_geom_predicates.",
+  #   call. = FALSE)
+  # }
 
   as.bcdc_promise(list(query_list = .data$query_list, cli = .data$cli, obj = .data$obj))
 }
@@ -227,7 +227,11 @@ collect.bcdc_promise <- function(x, ...){
   number_of_records <- bcdc_number_wfs_records(query_list, cli)
 
   if (number_of_records < 10000) {
-    cc <- cli$get(query = query_list)
+
+    body_filter <- list(cql_filter = query_list$CQL_FILTER)
+    query_list$CQL_FILTER <- NULL
+
+    cc <- cli$post(query = query_list, body = body_filter, encode = "form")
     status_failed <- cc$status_code >= 300
     url <- cc$url
   } else {

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -246,7 +246,7 @@ collect.bcdc_promise <- function(x, ...){
     tryCatch(cc$post(body = query_list, encode = "form"),
              error = function(e) {
                stop("The BC data catalogue experienced issues with this request.
-                     Try reducing the size of the object you are trying", call. = FALSE)})
+                     Try reducing the size of the object you are trying to retrieve.", call. = FALSE)})
 
     url <- cc$url_fetch(query = query_list)
 

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -220,7 +220,11 @@ collect.bcdc_promise <- function(x, ...){
   number_of_records <- bcdc_number_wfs_records(query_list, cli)
 
   if (number_of_records < 10000) {
-    cc <- cli$post(body = query_list, encode = "form")
+    cc <- tryCatch(cli$post(body = query_list, encode = "form"),
+             error = function(e) {
+               stop("The BC data catalogue experienced issues with this request.
+                     Try reducing the size of the object you are trying to retrieve.", call. = FALSE)})
+
     status_failed <- cc$status_code >= 300
     url <- cc$url
   } else {

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -34,7 +34,7 @@ print.bcdc_promise <- function(x, ...) {
 
   query_list <- c(x$query_list, COUNT = 6)
   cli <- x$cli
-  cc <- cli$get(query = query_list)
+  cc <- cli$post(body = query_list, encode = "form")
   cc$raise_for_status()
 
   number_of_records <- bcdc_number_wfs_records(x$query_list, x$cli)
@@ -150,13 +150,6 @@ filter.bcdc_promise <- function(.data, ...) {
                                    current_cql,
                                    drop_null = TRUE)
 
-  # if (!safe_request_length(.data$query_list)) {
-  #   stop("The vector you are trying to filter by is too long. Consider either breaking
-  #   up the request into two or more bcdc_query_geodata() calls or using a spatial
-  #   operator to spatial define your request. See ?cql_geom_predicates.",
-  #   call. = FALSE)
-  # }
-
   as.bcdc_promise(list(query_list = .data$query_list, cli = .data$cli, obj = .data$obj))
 }
 
@@ -227,11 +220,7 @@ collect.bcdc_promise <- function(x, ...){
   number_of_records <- bcdc_number_wfs_records(query_list, cli)
 
   if (number_of_records < 10000) {
-
-    body_filter <- list(cql_filter = query_list$CQL_FILTER)
-    query_list$CQL_FILTER <- NULL
-
-    cc <- cli$post(query = query_list, body = body_filter, encode = "form")
+    cc <- cli$post(body = query_list, encode = "form")
     status_failed <- cc$status_code >= 300
     url <- cc$url
   } else {
@@ -247,13 +236,18 @@ collect.bcdc_promise <- function(x, ...){
       limit_param = "count",
       offset_param = "startIndex",
       limit = number_of_records,
-      limit_chunk = 5000,
+      limit_chunk = 1000,
       progress = TRUE
     )
 
 
     message("Retrieving data")
-    cc$get(query = query_list)
+
+    tryCatch(cc$post(body = query_list, encode = "form"),
+             error = function(e) {
+               stop("The BC data catalogue experienced issues with this request.
+                     Try reducing the size of the object you are trying", call. = FALSE)})
+
     url <- cc$url_fetch(query = query_list)
 
     status_failed <- any(cc$status_code() >= 300)
@@ -292,18 +286,19 @@ collect.bcdc_promise <- function(x, ...){
 show_query.bcdc_promise <- function(x, ...) {
 
   x$query_list$CQL_FILTER <- finalize_cql(x$query_list$CQL_FILTER)
+  cql_filter <- x$query_list$CQL_FILTER
+  x$query_list$CQL_FILTER <- NULL
 
-  url <-  x$cli$url_fetch(query = x$query_list)
-
-  url <- url_format(url)
+  url <-  x$cli$url_fetch()
 
   cat_line("<url>")
   cat_line(url)
   cat_line()
-  cat_line("<SQL>")
-  cat_line(x$query_list$CQL_FILTER)
+  cat_line("<body>")
+  cat_line(glue::glue("   {names(x$query_list)}: {x$query_list}"))
+  cat_line(glue::glue("   CQL_FILTER: {substr(cql_filter, 1, 40)}..."))
 
-  invisible(x$cli$url_fetch(query = x$query_list))
+  invisible(TRUE)
 
 }
 
@@ -320,7 +315,10 @@ show_query.bcdc_promise <- function(x, ...) {
 #' }
 show_query.bcdc_sf <- function(x, ...) {
 
-  url <- url_format(attributes(x)$url)
+  url <- attributes(x)$url
+  query_list <- attributes(x)$query_list
+  cql_filter <- query_list$CQL_FILTER
+  query_list$CQL_FILTER <- NULL
 
   url <- paste0(url,"\n")
 
@@ -329,7 +327,13 @@ show_query.bcdc_sf <- function(x, ...) {
     cat_line(glue::glue("Request {i} of {length(url)} \n{url[i]} \n"))
   }
 
-  invisible(attributes(x)$url)
+  cat_line("<body>")
+  cat_line(glue::glue("   {names(query_list)}: {query_list}"))
+  cat_line(glue::glue("   CQL_FILTER: {substr(cql_filter, 1, 40)}..."))
+
+
+
+  invisible(TRUE)
 
 }
 

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -315,7 +315,7 @@ show_query.bcdc_promise <- function(x, ...) {
 #' }
 show_query.bcdc_sf <- function(x, ...) {
 
-  url <- attributes(x)$url
+  url <- attr(x, "url")
   query_list <- attributes(x)$query_list
   cql_filter <- query_list$CQL_FILTER
   query_list$CQL_FILTER <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,13 +21,12 @@ compact <- function(l) Filter(Negate(is.null), l)
 
 bcdc_number_wfs_records <- function(query_list, client){
 
-  query_list <- c(query_list, resultType = "hits")
-
   if(!is.null(query_list$propertyName)){
     query_list$propertyName <- NULL
   }
 
-  res_max <- client$get(query = query_list)
+  query_list <- c(resultType = "hits", query_list)
+  res_max <- client$post(body = query_list, encode = "form")
   txt_max <- res_max$parse("UTF-8")
 
   ## resultType is only returned as XML.
@@ -244,11 +243,6 @@ resource_to_tibble <- function(x){
 
 simplify_string <- function(x) {
   tolower(gsub("\\s+", "", x))
-}
-
-url_format <- function(url) {
-  url <- gsub("&", "&\n", url)
-  sub("SERVICE", "\nSERVICE", url)
 }
 
 pagination_sort_col <- function(x) {

--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -19,24 +19,24 @@ test_that("All cql geom predicate functions work", {
   for (f in single_arg_functions) {
     expect_equal(
       do.call(f, list(the_geom)),
-      CQL(paste0(f, "({geom_name}, POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)))"))
+      CQL(paste0(f, "({geom_name}, POINT (1 1))"))
       )
   }
   expect_equal(
     DWITHIN(the_geom, 1), #default units meters
-    CQL("DWITHIN({geom_name}, POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), 1, 'meters')")
+    CQL("DWITHIN({geom_name}, POINT (1 1), 1, 'meters')")
   )
   expect_equal(
     DWITHIN(the_geom, 1, "meters"),
-    CQL("DWITHIN({geom_name}, POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), 1, 'meters')")
+    CQL("DWITHIN({geom_name}, POINT (1 1), 1, 'meters')")
   )
   expect_equal(
     BEYOND(the_geom, 1, "feet"),
-    CQL("BEYOND({geom_name}, POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), 1, 'feet')")
+    CQL("BEYOND({geom_name}, POINT (1 1), 1, 'feet')")
   )
   expect_equal(
     RELATE(the_geom, "*********"),
-    CQL("RELATE({geom_name}, POLYGON ((1 1, 1 1, 1 1, 1 1, 1 1)), '*********')")
+    CQL("RELATE({geom_name}, POINT (1 1), '*********')")
   )
   expect_equal(
     BBOX(c(1,2,1,2)),

--- a/tests/testthat/test-query-geodata-collect.R
+++ b/tests/testthat/test-query-geodata-collect.R
@@ -59,8 +59,7 @@ test_that("bcdc_sf objects have a url as an attributes",{
     select(LATITUDE) %>%
     collect()
 
-  res <- readLines(attributes(sf_obj)$url, warn = FALSE)
-  expect_true(nzchar(res))
+  expect_true(nzchar(attributes(sf_obj)$url))
 })
 
 

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -111,14 +111,14 @@ test_that("subsetting works locally", {
                "(\"foo\" = 'b')")
 })
 
-test_that("large vectors supplied to filter fail with an error",{
+test_that("large vectors supplied to filter succeed",{
 
   pori <- bcdc_query_geodata("freshwater-atlas-stream-network") %>%
     filter(WATERSHED_GROUP_CODE %in% "PORI") %>%
     collect()
 
-  expect_error(bcdc_query_geodata("freshwater-atlas-stream-network") %>%
-    filter(WATERSHED_KEY %in% pori$WATERSHED_KEY[1:510]))
+  expect_silent(bcdc_query_geodata("freshwater-atlas-stream-network") %>%
+    filter(WATERSHED_KEY %in% pori$WATERSHED_KEY))
 
 })
 
@@ -147,7 +147,9 @@ test_that("multiple filter statements are additive with geometric operators",{
   ## LOCAL
   crd <- bcdc_query_geodata("regional-districts-legally-defined-administrative-areas-of-bc") %>%
     filter(ADMIN_AREA_NAME == "Cariboo Regional District") %>%
-    collect()
+    collect() %>%
+    st_bbox() %>%
+    st_as_sfc()
 
   ## REMOTE "GEOMETRY"
   em_program <- bcdc_query_geodata("employment-program-of-british-columbia-regional-boundaries") %>%
@@ -159,3 +161,36 @@ test_that("multiple filter statements are additive with geometric operators",{
   expect_equal(as.character(finalize_cql(em_program$query_list$CQL_FILTER)),
                cql_query)
 })
+
+
+test_that("an intersect with an object greater than 1E6 bytes automatically gets turned into a bbox",{
+  districts <- bcdc_query_geodata("78ec5279-4534-49a1-97e8-9d315936f08b") %>%
+    filter(SCHOOL_DISTRICT_NAME %in% c("Greater Victoria", "Prince George","Kamloops/Thompson")) %>%
+    collect()
+
+  expect_true(utils::object.size(districts) > 5E5)
+
+  expect_warning(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
+    filter(WITHIN(districts)) %>%
+      collect())
+
+  expect_equal(
+    as.character(attributes(parks)$query_list$CQL_FILTER),
+    "(WITHIN(SHAPE, POLYGON ((1126991 379215.8, 1528155 379215.8, 1528155 1224041, 1126991 1224041, 1126991 379215.8))))"
+  )
+})
+
+
+test_that("an intersect with an object less than 5E5 proceeds",{
+  small_districts <- bcdc_query_geodata("78ec5279-4534-49a1-97e8-9d315936f08b") %>%
+    filter(SCHOOL_DISTRICT_NAME %in% c("Prince George")) %>%
+    collect() %>%
+    st_bbox() %>%
+    st_as_sfc()
+
+
+  expect_silent(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
+    filter(WITHIN(small_districts)) %>%
+    collect())
+})
+

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -163,7 +163,7 @@ test_that("multiple filter statements are additive with geometric operators",{
 })
 
 
-test_that("an intersect with an object greater than 1E6 bytes automatically gets turned into a bbox",{
+test_that("an intersect with an object greater than 5E5 bytes automatically gets turned into a bbox",{
   districts <- bcdc_query_geodata("78ec5279-4534-49a1-97e8-9d315936f08b") %>%
     filter(SCHOOL_DISTRICT_NAME %in% c("Greater Victoria", "Prince George","Kamloops/Thompson")) %>%
     collect()
@@ -173,11 +173,6 @@ test_that("an intersect with an object greater than 1E6 bytes automatically gets
   expect_warning(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
     filter(WITHIN(districts)) %>%
       collect())
-
-  expect_equal(
-    as.character(attributes(parks)$query_list$CQL_FILTER),
-    "(WITHIN(SHAPE, POLYGON ((1126991 379215.8, 1528155 379215.8, 1528155 1224041, 1126991 1224041, 1126991 379215.8))))"
-  )
 })
 
 


### PR DESCRIPTION
This represents a major change to we access the WFS, accessing data via a `post` method rather than `get` method. As a result a simple url is no longer an accurate means of conveying how the query to WFS was carried out. As a result both `show_query` methods have been altered to reflect this.

Additional changes:
- A threshold of 500000B for the interesect object has been established, above which a bounding box is drawn.
- In the paginated response, I am trying to catch curl errors and just let the user know something went wrong, likely on the server side. 
- Because we are sending queries in the body of a `post`, issues raised in #55 no longer applies. 