### PR TITLE
Read data from zip files

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -173,9 +173,11 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, ...) {
 bcdc_read_functions <- function(){
   dplyr::tribble(
     ~format, ~package, ~fun,
-    "csv", "readr", "read_csv",
     "kml", "sf", "read_sf",
     "geojson", "sf", "read_sf",
+    "gpkg", "sf", "read_sf",
+    "shp", "sf", "read_sf",
+    "csv", "readr", "read_csv",
     "txt", "readr", "read_tsv",
     "xlsx", "readxl", "read_xlsx",
     "xls", "readxl", "read_xls"

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -172,14 +172,16 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, ...) {
 
 bcdc_read_functions <- function(){
   dplyr::tribble(
-    ~format, ~package, ~fun,
-    "kml", "sf", "read_sf",
-    "geojson", "sf", "read_sf",
-    "gpkg", "sf", "read_sf",
-    "shp", "sf", "read_sf",
-    "csv", "readr", "read_csv",
-    "txt", "readr", "read_tsv",
-    "xlsx", "readxl", "read_xlsx",
-    "xls", "readxl", "read_xls"
+    ~format,   ~package, ~fun,
+    "kml",     "sf",     "read_sf",
+    "geojson", "sf",     "read_sf",
+    "gpkg",    "sf",     "read_sf",
+    "gdb",     "sf",     "read_sf",
+    "shp",     "sf",     "read_sf",
+    "csv",     "readr",  "read_csv",
+    "txt",     "readr",  "read_tsv",
+    "tsv",     "readr",  "read_tsv",
+    "xlsx",    "readxl", "read_xlsx",
+    "xls",     "readxl", "read_xls"
   )
 }

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -177,6 +177,7 @@ bcdc_read_functions <- function(){
     "geojson", "sf",     "read_sf",
     "gpkg",    "sf",     "read_sf",
     "gdb",     "sf",     "read_sf",
+    "fgdb",    "sf",     "read_sf",
     "shp",     "sf",     "read_sf",
     "csv",     "readr",  "read_csv",
     "txt",     "readr",  "read_tsv",

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -112,12 +112,13 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, ...) {
 
   ## non-wms; resource specified
   if (!is.null(resource)) {
-    return(read_from_url(resource_df$url[resource_df$id == resource], ...))
+    return(read_from_url(resource_df[resource_df$id == resource, , drop = FALSE],
+                         ...))
   }
 
   ## non-wms; only one resource and not specified
   if (nrow(resource_df) == 1L) {
-    return(read_from_url(resource_df$url, ...))
+    return(read_from_url(resource_df, ...))
   }
 
   ## wms record with at least one non BCGW resource (test bc-airports)
@@ -145,12 +146,12 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, ...) {
     query <- bcdc_query_geodata(record = record_id, ...)
     return(collect(query))
   } else {
-    file_url <- resource_df$url[resource_df$name == name_choice]
+    resource <- resource_df[resource_df$name == name_choice, , drop = FALSE]
     id_choice <- resource_df$id[resource_df$name == name_choice]
 
     cat("To directly access this record in the future please use this command:\n")
     cat(glue::glue("bcdc_get_data('{record_id}', resource = '{id_choice}')"),"\n")
-    read_from_url(file_url, ...)
+    read_from_url(resource, ...)
   }
 }
 

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -75,12 +75,12 @@ record_print_helper <- function(r, n, print_avail = FALSE){
   cat(n, ") ", clean_wfs(r$name), "\n", sep = "")
   #cat("    description:", r$description, "\n")
   cat("     format:", clean_wfs(formats_from_resource(r)), "\n")
-  if(r$format != "wms") cat("     url:", r$url, "\n")
+  if (r$format != "wms") cat("     url:", r$url, "\n")
   cat("     resource:", r$id, "\n")
   if (print_avail) {
     cat("     available in R via bcdata: ",
         if (r$format == "zip") {
-          "Will attempt - unkown format (zipped)"
+          "Will attempt - unknown format (zipped)"
         } else {
           r$bcdata_available
         }, "\n")

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -77,8 +77,14 @@ record_print_helper <- function(r, n, print_avail = FALSE){
   cat("     format:", clean_wfs(formats_from_resource(r)), "\n")
   if(r$format != "wms") cat("     url:", r$url, "\n")
   cat("     resource:", r$id, "\n")
-  if (print_avail)
-    cat("     available in R via bcdata: ", r$bcdata_available, "\n")
+  if (print_avail) {
+    cat("     available in R via bcdata: ",
+        if (r$format == "zip") {
+          "Will attempt - unkown format (zipped)"
+        } else {
+          r$bcdata_available
+        }, "\n")
+  }
   if (r$bcdata_available)
     cat("     code: bcdc_get_data(record = '", r$package_id,
         "', resource = '",r$id,"')\n", sep = "")

--- a/R/utils.R
+++ b/R/utils.R
@@ -277,7 +277,6 @@ handle_zip <- function(x) {
   }
   dir <- dirname(x)
   unzip(x, exdir = dir)
-  unlink(x)
   files <- list.files(dir, full.names = TRUE, recursive = TRUE)
   shp <- tools::file_ext(files) == "shp"
   if (any(shp)) {
@@ -285,7 +284,9 @@ handle_zip <- function(x) {
   }
 
   if (length(files) > 1L) {
-    stop("More than one file in zip", call. = FALSE)
+    stop("More than one file in zip file. It has been downloaded to '",
+         x, "', where you can access it and its contents manually.",
+         call. = FALSE)
   }
   files
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -219,7 +219,8 @@ read_from_url <- function(resource, ...){
   cli <- bcdc_http_client(file_url)
 
   ## Establish where to download file
-  tmp <- tempfile(fileext = paste0(".", tools::file_ext(file_url)))
+  tmp <- tempfile(tmpdir = unique_temp_dir(),
+                  fileext = paste0(".", tools::file_ext(file_url)))
   on.exit(unlink(tmp))
 
   r <- cli$get(disk = tmp)
@@ -301,4 +302,10 @@ handle_zip <- function(x) {
 
 is_filetype <- function(x, ext) {
   tools::file_ext(x) %in% ext
+}
+
+unique_temp_dir <- function(pattern = "bcdata_") {
+  dir <- tempfile(pattern = pattern)
+  dir.create(file.path(dirname(dir), basename(dir)))
+  dir
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -280,7 +280,7 @@ handle_zip <- function(x) {
   }
   # decompress into same dir
   dir <- dirname(x)
-  unzip(x, exdir = dir)
+  utils::unzip(x, exdir = dir)
   files <- list.files(dir, full.names = TRUE, recursive = TRUE)
   # check if it's a shapefile
   shp <- is_filetype(files, "shp")

--- a/R/utils.R
+++ b/R/utils.R
@@ -225,6 +225,8 @@ read_from_url <- function(resource, ...){
   r <- cli$get(disk = tmp)
   r$raise_for_status()
 
+  tmp <- handle_zip(tmp)
+
   # Match the read function to the file format format and retrieve the function
   funs <- bcdc_read_functions()
   fun <- funs[funs$format == format, ]
@@ -267,4 +269,23 @@ pagination_sort_col <- function(x) {
           "). Please check your data for obvious duplicated or missing rows.",
           call. = FALSE)
   cols[1]
+}
+
+handle_zip <- function(x) {
+  if (!tools::file_ext(x) == "zip") {
+    return(x)
+  }
+  dir <- dirname(x)
+  unzip(x, exdir = dir)
+  unlink(x)
+  files <- list.files(dir, full.names = TRUE, recursive = TRUE)
+  shp <- tools::file_ext(files) == "shp"
+  if (any(shp)) {
+    files <- files[shp]
+  }
+
+  if (length(files) > 1L) {
+    stop("More than one file in zip", call. = FALSE)
+  }
+  files
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -241,7 +241,8 @@ read_from_url <- function(resource, ...){
   tryCatch(do.call(fun$fun, list(tmp, ...)),
            error = function(e) {
              stop("Could not read data set. The file can be found here:\n '",
-                  tmp, "'\n if you would like to try to read it manually.\n\n")
+                  tmp, "'\n if you would like to try to read it manually.\n\n",
+                  call. = FALSE)
            })
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,7 +238,11 @@ read_from_url <- function(resource, ...){
   # where that's not the case
   message("Reading the data using the ", fun$fun, " function from the ",
           fun$package, " package.")
-  do.call(fun$fun, list(tmp, ...))
+  tryCatch(do.call(fun$fun, list(tmp, ...)),
+           error = function(e) {
+             stop("Could not read data set. The file can be found here:\n '",
+                  tmp, "'\n if you would like to try to read it manually.\n\n")
+           })
 }
 
 resource_to_tibble <- function(x){

--- a/R/utils.R
+++ b/R/utils.R
@@ -273,12 +273,15 @@ pagination_sort_col <- function(x) {
 }
 
 handle_zip <- function(x) {
+  # Just give file back if it's not zipped
   if (!tools::file_ext(x) == "zip") {
     return(x)
   }
+  # decompress into same dir
   dir <- dirname(x)
   unzip(x, exdir = dir)
   files <- list.files(dir, full.names = TRUE, recursive = TRUE)
+  # check if it's a shapefile
   shp <- tools::file_ext(files) == "shp"
   if (any(shp)) {
     files <- files[shp]

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,7 +274,7 @@ pagination_sort_col <- function(x) {
 
 handle_zip <- function(x) {
   # Just give file back if it's not zipped
-  if (!tools::file_ext(x) == "zip") {
+  if (!is_filetype(x, "zip")) {
     return(x)
   }
   # decompress into same dir
@@ -282,19 +282,23 @@ handle_zip <- function(x) {
   unzip(x, exdir = dir)
   files <- list.files(dir, full.names = TRUE, recursive = TRUE)
   # check if it's a shapefile
-  shp <- tools::file_ext(files) == "shp"
+  shp <- is_filetype(files, "shp")
   if (any(shp)) {
     files <- files[shp]
   }
 
   if (length(files) > 1L) {
     stop("More than one file in zip file. It has been downloaded and extracted to '",
-         x, "', where you can access its contents manually.",
+         dir, "', where you can access its contents manually.",
          call. = FALSE)
   }
 
-  if (!tools::file_ext(files) %in% formats_supported()) {
+  if (!is_filetype(files, formats_supported())) {
     stop("Unknown format in zip file.")
   }
   files
+}
+
+is_filetype <- function(x, ext) {
+  tools::file_ext(x) %in% ext
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -294,7 +294,7 @@ handle_zip <- function(x) {
   }
 
   if (!tools::file_ext(files) %in% formats_supported()) {
-    stop("Unkown format in zip file.")
+    stop("Unknown format in zip file.")
   }
   files
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ An R package 📦 for searching & retrieving data from the [B.C. Data Catalogue]
 - `bcdc_query_geodata()` - Get & query catalogue geospatial data available through a [Web Service](https://www2.gov.bc.ca/gov/content?id=95D78D544B244F34B89223EF069DF74E)
 
 **Note:** The `bcdata` package supports downloading _most_ file types, including zip archives. It will do its best to identify and read data from
-zip files, however if there are multiple data files in the zip, or data files that bcdata doesn't know how to import, it will fail. 
+zip files, however if there are multiple data files in the zip, or data files that `bcdata` doesn't know how to import, it will fail. 
 If you encounter a file type in the B.C. Data Catalogue not currently supported by `bcdata` please file an [issue](https://github.com/bcgov/bcdata/issues/). 
 
 ### Reference

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,7 +51,9 @@ An R package 📦 for searching & retrieving data from the [B.C. Data Catalogue]
 - `bcdc_get_data()` - Get catalogue data
 - `bcdc_query_geodata()` - Get & query catalogue geospatial data available through a [Web Service](https://www2.gov.bc.ca/gov/content?id=95D78D544B244F34B89223EF069DF74E)
 
-The `bcdata` package supports downloading _most_ file types, however the package does _not_ retrieve .zip or compressed resource files at this time. If you encounter a file type in the B.C. Data Catalogue not currently supported by `bcdata` please file an [issue](https://github.com/bcgov/bcdata/issues/). 
+**Note:** The `bcdata` package supports downloading _most_ file types, including zip archives. It will do its best to identify and read data from
+zip files, however if there are multiple data files in the zip, or data files that bcdata doesn't know how to import, it will fail. 
+If you encounter a file type in the B.C. Data Catalogue not currently supported by `bcdata` please file an [issue](https://github.com/bcgov/bcdata/issues/). 
 
 ### Reference
 [bcdata package 📦 home page and reference guide](https://bcgov.github.io/bcdata/)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Catalogue](https://catalogue.data.gov.bc.ca).
 **Note:** The `bcdata` package supports downloading *most* file types,
 including zip archives. It will do its best to identify and read data
 from zip files, however if there are multiple data files in the zip, or
-data files that bcdata doesn’t know how to import, it will fail. If you
-encounter a file type in the B.C. Data Catalogue not currently supported
-by `bcdata` please file an
+data files that `bcdata` doesn’t know how to import, it will fail. If
+you encounter a file type in the B.C. Data Catalogue not currently
+supported by `bcdata` please file an
 [issue](https://github.com/bcgov/bcdata/issues/).
 
 ### Reference

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ Catalogue](https://catalogue.data.gov.bc.ca).
     available through a [Web
     Service](https://www2.gov.bc.ca/gov/content?id=95D78D544B244F34B89223EF069DF74E)
 
-The `bcdata` package supports downloading *most* file types, however the
-package does *not* retrieve .zip or compressed resource files at this
-time. If you encounter a file type in the B.C. Data Catalogue not
-currently supported by `bcdata` please file an
+**Note:** The `bcdata` package supports downloading *most* file types,
+including zip archives. It will do its best to identify and read data
+from zip files, however if there are multiple data files in the zip, or
+data files that bcdata doesn’t know how to import, it will fail. If you
+encounter a file type in the B.C. Data Catalogue not currently supported
+by `bcdata` please file an
 [issue](https://github.com/bcgov/bcdata/issues/).
 
 ### Reference

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -47,6 +47,12 @@ test_that("bcdc_get_data will return non-wms resources",{
                           resource = 'dc1098a7-a4b8-49a3-adee-9badd4429279'), "tbl")
 })
 
+test_that("bcdc_get_data works with a zipped shp file", {
+  expect_is(bcdc_get_data(record = '68f2f577-28a7-46b4-bca9-7e9770f2f357',
+                          resource = 'f89f99b0-ca68-41e2-afc4-63fdc0edb666'),
+            "sf")
+})
+
 
 test_that("bcdc_get_data can return the wms resource when it is specified by resource",{
   expect_is(bcdc_get_data("bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"), "sf")

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -53,9 +53,14 @@ test_that("bcdc_get_data works with a zipped shp file", {
             "sf")
 })
 
-test_that("unknown file type (shp) inside zip", {
+test_that("unknown single file (shp) inside zip", {
   expect_is(bcdc_get_data("e31f7488-27fa-4330-ae86-160a0deb8a59"),
             "sf")
+})
+
+test_that("fails when multiple files in a zip", {
+  expect_error(bcdc_get_data("300c0980-b5e3-4202-b0da-d816f14fadad"),
+               "More than one file in zip file")
 })
 
 test_that("bcdc_get_data can return the wms resource when it is specified by resource",{

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -60,7 +60,13 @@ test_that("unknown single file (shp) inside zip", {
 
 test_that("fails when multiple files in a zip", {
   expect_error(bcdc_get_data("300c0980-b5e3-4202-b0da-d816f14fadad"),
-               "More than one file in zip file")
+               "More than one supported file in zip file")
+})
+
+test_that("fails informatively when can't read a file", {
+  expect_error(bcdc_get_data(record = '523dce9d-b464-44a5-b733-2022e94546c3',
+                             resource = '4cc98644-f6eb-410b-9df0-f9b2beac9717'),
+               "Could not read data set")
 })
 
 test_that("bcdc_get_data can return the wms resource when it is specified by resource",{

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -53,6 +53,10 @@ test_that("bcdc_get_data works with a zipped shp file", {
             "sf")
 })
 
+test_that("unknown file type (shp) inside zip", {
+  expect_is(bcdc_get_data("e31f7488-27fa-4330-ae86-160a0deb8a59"),
+            "sf")
+})
 
 test_that("bcdc_get_data can return the wms resource when it is specified by resource",{
   expect_is(bcdc_get_data("bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"), "sf")

--- a/vignettes/bcdata.Rmd
+++ b/vignettes/bcdata.Rmd
@@ -154,7 +154,7 @@ bc_az %>%
 ```
 
 **Note:** The `bcdata` package supports downloading _most_ file types, including zip archives. It will do its best to identify and read data from
-zip files, however if there are multiple data files in the zip, or data files that bcdata doesn't know how to import, it will fail.
+zip files, however if there are multiple data files in the zip, or data files that `bcdata` doesn't know how to import, it will fail.
 
 ### `bcdc_query_geodata()`
 

--- a/vignettes/bcdata.Rmd
+++ b/vignettes/bcdata.Rmd
@@ -153,8 +153,8 @@ bc_az %>%
   geom_sf()
 ```
 
-**Note:** The `bcdata` package supports downloading _most_ file types, however the package does _not_ retrieve .zip or compressed resource files at this time.
-
+**Note:** The `bcdata` package supports downloading _most_ file types, including zip archives. It will do its best to identify and read data from
+zip files, however if there are multiple data files in the zip, or data files that bcdata doesn't know how to import, it will fail.
 
 ### `bcdc_query_geodata()`
 


### PR DESCRIPTION
This allows zip resources to be downloaded and read in, and adds support for `.shp`, `.gpkg`, and `.gdb` files. It extracts the zip file and fails if there is more (or less) than one type of supported file, otherwise reads any supported file type normally. 

I think this opens the door for more failures, so I also added a `tryCatch` statement around the reading to give a more informative error message if reading fails.

Closes #84 