### PR TITLE
better general handling of objects not found. Closes #130

### DIFF
--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -41,10 +41,16 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
                             distance = NULL, units = NULL,
                             coords = NULL, crs = NULL){
 
+  if (inherits(x, "sql")) {
+    stop(glue::glue("object {as.character(x)} not found.\n The object passed to {geometry_predicates} needs to be valid sf object."),
+         call. = FALSE)
+  }
+
   if(inherits(x, "bcdc_promise")) {
     stop("To use spatial operators, you need to use collect() to retrieve the object used to filter",
          call. = FALSE)
   }
+
 
   geom_col <- attr(x, "geom_col")
   if(is.null(geom_col)) geom_col <- "GEOMETRY"
@@ -85,10 +91,13 @@ cql_geom_predicate_list <- function() {
 }
 
 sf_text <- function(x) {
+
   if (!inherits(x, c("sf", "sfc", "sfg"))) {
     stop(paste(deparse(substitute(x)), "is not a valid sf object"),
          call. = FALSE)
   }
+
+
 
   ## If too big here, drawing bounding
   if(utils::object.size(x) > getOption("bcdata.max_geom_pred_size", 5E5)){

--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -85,3 +85,9 @@ test_that("unsupported aggregation functions fail correctly", {
   expect_error(filter(structure(list(), class = "bcdc_promise"), mean(x) > 5),
                "not supported by this database")
 })
+
+test_that("passing an non-existent object to a geom predicate",{
+  expect_error(bcdc_query_geodata("6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
+                 filter(INTERSECTS(districts)),
+               'object "districts" not found.\nThe object passed to INTERSECTS needs to be valid sf object.')
+})


### PR DESCRIPTION
The behaviour is now:

```
> bcdc_query_geodata("6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
   filter(PARK_PRIMARY_USE == "Park") %>% 
   filter(INTERSECTS(districts))
Error: object "districts" not found.
The object passed to INTERSECTS needs to be valid sf object.
```

I would appreciate a 2nd set of eyes here.
