### PR TITLE
Get typeName for wfs from resource url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # bcdata (development version)
 
 # bcdata 0.1.1.9999
+
+* More reliable detection of layer name for a wfs call in `bcdc_query_geodata()` (#129, #138, #139)
 * Fixed a bug where `BBOX()` used in a `filter()` statement combined with `bcdc_query_geodata()` did not work (#135, #137)
 * Add `mutate` method for bcdc_promise that only fails and suggest an alternative approach. (PR#134)
+* Fixed a bug where layer names with a number in them would not work in `bcdc_query_geodata()` (#126, #127)
 * Add back in querying vignette
 
 # bcdata 0.1.1

--- a/R/bcdc-web-services.R
+++ b/R/bcdc-web-services.R
@@ -117,8 +117,12 @@ bcdc_query_geodata.bcdc_record <- function(record, crs = 3005) {
     )
   }
 
+  layer_name <- basename(dirname(
+    record$resource_df$url[record$resource_df$format == "wms"]
+  ))
+
   ## Parameters for the API call
-  query_list <- make_query_list(layer_name = record$layer_name, crs = crs)
+  query_list <- make_query_list(layer_name = layer_name, crs = crs)
 
   ## Drop any NULLS from the list
   query_list <- compact(query_list)

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -9,7 +9,7 @@ test_that("recods with wms but inconsistent layer_name, object_name fieldds work
 
   # https://github.com/bcgov/bcdata/issues/129
   # layer_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SPG
-  # objec_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SP
+  # object_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SP
   # wms uses layer_name (generalized)
   expect_is(bcdc_query_geodata("natural-resource-nr-district"), "bcdc_promise")
 })

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -1,0 +1,15 @@
+context("Edge cases and catalogue peculiarities")
+
+test_that("recods with wms but inconsistent layer_name, object_name fieldds work", {
+  # https://github.com/bcgov/bcdata/issues/138
+  # layer_name = RSLT_PLANTING_ALL_RSLT_CF
+  # object_name = WHSE_FOREST_VEGETATION.RSLT_PLANTING_SVW
+  # wms uses object_name
+  expect_is(bcdc_query_geodata("results-planting"), "bcdc_promise")
+
+  # https://github.com/bcgov/bcdata/issues/129
+  # layer_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SPG
+  # objec_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SP
+  # wms uses layer_name (generalized)
+  expect_is(bcdc_query_geodata("natural-resource-nr-district"), "bcdc_promise")
+})


### PR DESCRIPTION
Rather than pull the layer name to pass to the `typeNames` parameter in the WFS request, this gets it from the url of the wfs resource. This is because records have both a `layer_name` and an `object_name` and you can't count on the wfs/wms to use a particular one. See #138 and #129.

I also added a new test file for these kinds of edge cases.

One more thing that could be added to this PR is fixing #133, as it is related.