### PR TITLE
Two wfs

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -87,6 +87,7 @@ print.bcdc_record <- function(x, ...) {
 record_print_helper <- function(r, n, print_avail = FALSE){
   cat(n, ") ", clean_wfs(r$name), "\n", sep = "")
   #cat("    description:", r$description, "\n")
+  cat("     warehouse name:", ifelse(is_whse_object_name(r$whse_name), r$whse_name, NA_character_), "\n")
   cat("     format:", clean_wfs(formats_from_resource(r)), "\n")
   if (r$format != "wms") cat("     url:", r$url, "\n")
   cat("     resource:", r$id, "\n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -184,6 +184,7 @@ get_record_warn_once <- function(...) {
 clean_wfs <- function(x){
   dplyr::case_when(
     x == "WMS getCapabilities request" ~ "WFS request (Spatial Data)",
+    x == "WMS getCapabilities request (Generalized View)" ~ "WFS request (Spatial Data)",
     x == "wms" ~ "wfs",
     TRUE ~ x
   )
@@ -231,6 +232,7 @@ resource_to_tibble <- function(x){
   dplyr::tibble(
     name = purrr::map_chr(x, "name"),
     url = purrr::map_chr(x, "url"),
+    whse_name = parse_url_for_whse_name(url),
     id = purrr::map_chr(x, "id"),
     format = purrr::map_chr(x, "format"),
     ext = purrr::map_chr(x, safe_file_ext),
@@ -335,4 +337,16 @@ catch_catalogue_error <- function(catalogue_response) {
   if (status_failed) {
     stop(msg, call. = FALSE)
   }
+}
+
+get_whse_from_resource <- function(record, resource){
+
+  #record <- bcdc_get_record(record)
+  rdf <- record$resource_df$url[record$resource_df$id == resource]
+  parse_url_for_whse_name(rdf)
+
+}
+
+parse_url_for_whse_name <- function(x) {
+  basename(dirname(x))
 }


### PR DESCRIPTION
A few steps to this PR. 

First step is to provide print methods that better allow a user to distinguish between multi-wfs resources: 

<details><summary>Record printing</summary>

```
> bcdc_get_record('25bbc9a6-f0eb-47dd-849c-3161a6512468')
B.C. Data Catalogue Record:
    Forest Development Units 

Name: forest-development-units (ID: 25bbc9a6-f0eb-47dd-849c-3161a6512468 )
Permalink: https://catalogue.data.gov.bc.ca/dataset/25bbc9a6-f0eb-47dd-849c-3161a6512468
Sector: Natural Resources
Licence: Open Government Licence - British Columbia
Type: Geographic
Last Updated: 2019-09-05 

Description:
    The spatial representation of a Forest Stewardship Plan and Forest Development
    Units. A Forest Stewardship Plan is a plan submitted by a forest industry licensee
    stating how the BC Government's objectives for managing the province's forest
    resources will be met. It identifies the plan-holder's obligations for a five-year
    period. The Forest Development Unit is the spatially-mapped area of land within a
    Forest Stewardship Plan where specific forest practices obligations apply to
    specific forest licensees. 

Resources: ( 5 )
1) BC Geographic Warehouse Custom Download
     warehouse name: NA 
     format: other 
     url: https://catalogue.data.gov.bc.ca/api/ofi/other/WHSE_FOREST_TENURE.FSP_FDU_POLY_SVW 
     resource: ad46cd04-41c4-4fea-aaab-bc8cb3156d18 
     available in R via bcdata:  FALSE 

2) WFS request (Spatial Data)
     warehouse name: WHSE_FOREST_TENURE.FSP_FDU_POLY_SVW 
     format: wfs 
     resource: 030dc223-b3e2-435d-864c-98d5ec4bd2c7 
     available in R via bcdata:  TRUE 
     code: bcdc_get_data(record = '25bbc9a6-f0eb-47dd-849c-3161a6512468', resource = '030dc223-b3e2-435d-864c-98d5ec4bd2c7')

3) WFS request (Spatial Data)
     warehouse name: WHSE_FOREST_TENURE.FSP_FDU_POLY_300K_SPG 
     format: wfs 
     resource: 13545498-b47d-488a-9e65-107e3af998be 
     available in R via bcdata:  TRUE 
     code: bcdc_get_data(record = '25bbc9a6-f0eb-47dd-849c-3161a6512468', resource = '13545498-b47d-488a-9e65-107e3af998be')

4) WFS request (Spatial Data)
     warehouse name: WHSE_FOREST_TENURE.FSP_FDU_POLY_50K_SPG 
     format: wfs 
     resource: a8d6a382-bbed-439a-a933-f289479b08d1 
     available in R via bcdata:  TRUE 
     code: bcdc_get_data(record = '25bbc9a6-f0eb-47dd-849c-3161a6512468', resource = 'a8d6a382-bbed-439a-a933-f289479b08d1')

5) KML Network Link
     warehouse name: NA 
     format: kml 
     url: http://openmaps.gov.bc.ca/kml/geo/layers/WHSE_FOREST_TENURE.FSP_FDU_POLY_SVW_loader.kml 
     resource: dac6326d-e87e-4549-8fd1-b19b716e3898 
     available in R via bcdata:  FALSE 
```

</details>