### PR TITLE
record_list no longer fails when a record has no resources. Closes #128

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -114,7 +114,7 @@ print.bcdc_recordlist <- function(x, ...) {
   x <- purrr::set_names(x, NULL)
   cat(paste(purrr::imap(x[1:n_print], ~ {
 
-    if (nrow(x[[.y]][["resource_df"]]) == 0) {
+    if (!nrow(bcdc_tidy_resources(x[[.y]]))) {
       return(paste0(.y, ": ",purrr::pluck(.x, "title"),
                     col_red("\n This record has no resources. bcdata will not be able to access any data."),
                     "\n ID: ", purrr::pluck(.x, "id"),

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -113,6 +113,14 @@ print.bcdc_recordlist <- function(x, ...) {
   cat("\nTitles:\n")
   x <- purrr::set_names(x, NULL)
   cat(paste(purrr::imap(x[1:n_print], ~ {
+
+    if (nrow(x[[.y]][["resource_df"]]) == 0) {
+      return(paste0(.y, ": ",purrr::pluck(.x, "title"),
+                    col_red("\n This record has no resources. bcdata will not be able to access any data."),
+                    "\n ID: ", purrr::pluck(.x, "id"),
+                    "\n Name: ", purrr::pluck(.x, "name")))
+    }
+
     paste0(
       .y, ": ",purrr::pluck(.x, "title"),
       " (",

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -1,0 +1,18 @@
+# Copyright 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+context('test bcdc_search')
+
+
+test_that('works with a record that has no resource',{
+  expect_silent(bcdc_search("Major Railways"))
+})

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -13,6 +13,15 @@
 context('test bcdc_search')
 
 
-test_that('works with a record that has no resource',{
-  expect_silent(bcdc_search("Major Railways"))
+test_that('works with a record that has no resource', {
+  skip_on_cran()
+  skip_if_net_down()
+  output_path <- tempfile()
+  suppressWarnings(
+    verify_output(output_path, {
+      bcdc_search("Major Railways")
+    })
+  )
+  expect_false(any(grepl("Error", readLines(output_path))))
+  expect_true(any(grepl("no resources", readLines(output_path))))
 })


### PR DESCRIPTION
What about this error message?

```
> bcdc_search("Major Railways")
List of B.C. Data Catalogue Records

Number of records: 2
Titles:
1: (7.5M) Major Railways - The Atlas of Canada Base Maps for BC
 This record has no resources. bcdata will not be able to access any data.
 ID: 7b6d9196-7036-4b9a-bb78-e13b1d08068a
 Name: 7-5m-major-railways-the-atlas-of-canada-base-maps-for-bc
2: (7.5M) Major Railways - The Atlas of Canada Base Maps (other)
 ID: c894310a-1f86-419f-b0ac-c5a71a8ff2e5
 Name: 7-5m-major-railways-the-atlas-of-canada-base-maps 

Access a single record by calling bcdc_get_record(ID)
      with the ID from the desired record.
```