### PR TITLE
bbox fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,4 +58,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bcdata (development version)
 
+* Geometry predicates can now take a `bbox` object as well as an `sf*` object (#176)
+
 # bcdata 0.1.2
 
 ### IMPROVEMENTS

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -194,6 +194,16 @@ BBOX <- function(coords, crs = NULL){
   if (!is.numeric(coords) || length(coords) != 4L) {
     stop("'coords' must be a length 4 numeric vector", call. = FALSE)
   }
+
+  if (inherits(coords, "bbox")) {
+    crs <- sf::st_crs(coords)[["epsg"]]
+    coords <- as.numeric(coords)
+  }
+
+  if (is.numeric(crs)) {
+    crs <- paste0("EPSG:", crs)
+  }
+
   if (!is.null(crs) && !(is.character(crs) && length(crs) == 1L)) {
     stop("crs must be a character string denoting the CRS (e.g., 'EPSG:4326')",
          call. = FALSE)

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -118,7 +118,7 @@ sf_text <- function(x) {
 #' bounding box to reduce the complexity of the Web Service call. Subsequent in-memory
 #' filtering may be needed to achieve exact results.
 #'
-#' @param geom an sf/sfc/sfg object
+#' @param geom an `sf`/`sfc`/`sfg` or `bbox` object (from the `sf` package)
 #' @name cql_geom_predicates
 #' @return a CQL expression to be passed on to the WFS call
 NULL
@@ -190,8 +190,10 @@ RELATE <- function(geom, pattern) {
 #' @param coords the coordinates of the bounding box as four-element numeric
 #'        vector `c(xmin, ymin, xmax, ymax)`, or a `bbox` object from the `sf`
 #'        package (the result of running `sf::st_bbox()` on an `sf` object).
-#' @param crs (Optional) A string containing an SRS code
-#' (For example, 'EPSG:1234'. The default is to use the CRS of the queried layer)
+#' @param crs (Optional) A numeric value or string containing an SRS code. If
+#' `coords` is a `bbox` object with non-empty crs, it is taken from that.
+#' (For example, `'EPSG:3005'` or just `3005`. The default is to use the CRS of
+#' the queried layer)
 #' @export
 BBOX <- function(coords, crs = NULL){
   if (!is.numeric(coords) || length(coords) != 4L) {

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -43,7 +43,7 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
          call. = FALSE)
   }
 
-  if(inherits(x, "bcdc_promise")) {
+  if (inherits(x, "bcdc_promise")) {
     stop("To use spatial operators, you need to use collect() to retrieve the object used to filter",
          call. = FALSE)
   }
@@ -53,6 +53,7 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
   # Only convert x to bbox if not using BBOX CQL function
   # because it doesn't take a geom
   if (!geometry_predicates == "BBOX") {
+    if (inherits(x, "bbox")) x <- sf::st_as_sfc(x)
     x <- sf_text(x)
   }
 

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -53,7 +53,6 @@ bcdc_cql_string <- function(x, geometry_predicates, pattern = NULL,
   # Only convert x to bbox if not using BBOX CQL function
   # because it doesn't take a geom
   if (!geometry_predicates == "BBOX") {
-    if (inherits(x, "bbox")) x <- sf::st_as_sfc(x)
     x <- sf_text(x)
   }
 
@@ -85,21 +84,24 @@ cql_geom_predicate_list <- function() {
 
 sf_text <- function(x) {
 
-  if (!inherits(x, c("sf", "sfc", "sfg"))) {
+  if (!inherits(x, c("sf", "sfc", "sfg", "bbox"))) {
     stop(paste(deparse(substitute(x)), "is not a valid sf object"),
          call. = FALSE)
   }
 
   ## If too big here, drawing bounding
-  if(utils::object.size(x) > getOption("bcdata.max_geom_pred_size", 5E5)){
+  if (utils::object.size(x) > getOption("bcdata.max_geom_pred_size", 5E5)) {
     warning("The object is too large to perform exact spatial operations using bcdata.
              To simplify the polygon, a bounding box was drawn around the polygon and all
              features within the box will be returned. Options include further processing
              with on the returned object or simplify the object.", call. = FALSE)
-    x = sf::st_bbox(x)
-    x = sf::st_as_sfc(x)
-  } else{
-    x = sf::st_union(x)
+    x <- sf::st_bbox(x)
+  }
+
+  if (inherits(x, "bbox")) {
+    x <- sf::st_as_sfc(x)
+  } else {
+    x <- sf::st_union(x)
   }
 
   sf::st_as_text(x)

--- a/R/cql-translator.R
+++ b/R/cql-translator.R
@@ -87,7 +87,7 @@ cql_scalar <- dbplyr::sql_translator(
   RELATE = function(geom, pattern) RELATE(geom, pattern),
   DWITHIN = function(geom, distance, units) DWITHIN(geom, distance, units),
   BEYOND = function(geom, distance, units) BEYOND(geom, distance, units),
-  BBOX = function(coords, crs) BBOX(coords, crs),
+  BBOX = function(coords, crs = NULL) BBOX(coords, crs),
   CQL = function(...) CQL(...)
 )
 

--- a/man/cql_geom_predicates.Rd
+++ b/man/cql_geom_predicates.Rd
@@ -39,14 +39,16 @@ DWITHIN(
 )
 }
 \arguments{
-\item{geom}{an sf/sfc/sfg object}
+\item{geom}{an \code{sf}/\code{sfc}/\code{sfg} or \code{bbox} object (from the \code{sf} package)}
 
 \item{coords}{the coordinates of the bounding box as four-element numeric
 vector \code{c(xmin, ymin, xmax, ymax)}, or a \code{bbox} object from the \code{sf}
 package (the result of running \code{sf::st_bbox()} on an \code{sf} object).}
 
-\item{crs}{(Optional) A string containing an SRS code
-(For example, 'EPSG:1234'. The default is to use the CRS of the queried layer)}
+\item{crs}{(Optional) A numeric value or string containing an SRS code. If
+\code{coords} is a \code{bbox} object with non-empty crs, it is taken from that.
+(For example, \code{'EPSG:3005'} or just \code{3005}. The default is to use the CRS of
+the queried layer)}
 
 \item{distance}{numeric value for distance tolerance}
 

--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -75,8 +75,6 @@ test_that("CQL functions fail correctly", {
   expect_error(RELATE(the_geom, rep("TTTTTTTTT", 2)), "pattern") # > length 1
   expect_error(BBOX(c(1,2,3)), "numeric vector")
   expect_error(BBOX(c("1","2","3", "4")), "numeric vector")
-  expect_error(BBOX(c(1,2,3,4), crs = 4326), "must be a character string")
-  expect_error(BBOX(c(1,2,3,4), crs = 4326), "must be a character string")
   expect_error(BBOX(c(1,2,3,4), crs = c("EPSG:4326", "EPSG:3005")),
                "must be a character string")
 })

--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -63,6 +63,10 @@ test_that("All cql geom predicate functions work", {
     BBOX(c(1,2,1,2), crs = 'EPSG:4326'),
     CQL("BBOX({geom_name}, 1, 2, 1, 2, 'EPSG:4326')")
   )
+  expect_equal(
+    BBOX(c(1,2,1,2), crs = 4326),
+    CQL("BBOX({geom_name}, 1, 2, 1, 2, 'EPSG:4326')")
+  )
 })
 
 test_that("CQL functions fail correctly", {

--- a/tests/testthat/test-geom-operators.R
+++ b/tests/testthat/test-geom-operators.R
@@ -33,7 +33,7 @@ test_that("WITHIN works",{
 })
 
 
-test_that("INTERSECT works",{
+test_that("INTERSECTS works",{
   skip_on_cran()
   skip_if_net_down()
 
@@ -86,6 +86,34 @@ test_that("BEYOND works", {
   remote <- suppressWarnings(
     bcdc_query_geodata("bc-parks-ecological-reserves-and-protected-areas") %>%
       filter(BEYOND(local, 100, "meters")) %>%
+      collect()
+  )
+
+  expect_is(remote, "sf")
+  expect_equal(attr(remote, "sf_column"), "geometry")
+})
+
+test_that("BBOX works with an sf bbox", {
+  skip_on_cran()
+  skip_if_net_down()
+
+  remote <- suppressWarnings(
+    bcdc_query_geodata("bc-parks-ecological-reserves-and-protected-areas") %>%
+      filter(FEATURE_LENGTH_M <= 1000, BBOX(sf::st_bbox(local))) %>%
+      collect()
+  )
+
+  expect_is(remote, "sf")
+  expect_equal(attr(remote, "sf_column"), "geometry")
+})
+
+test_that("Other predicates work with an sf bbox", {
+  skip_on_cran()
+  skip_if_net_down()
+
+  remote <- suppressWarnings(
+    bcdc_query_geodata("bc-parks-ecological-reserves-and-protected-areas") %>%
+      filter(FEATURE_LENGTH_M <= 1000, INTERSECTS(sf::st_bbox(local))) %>%
       collect()
   )
 


### PR DESCRIPTION
Allow geometry predicates (E.g., `INTERSECTS()`, `BBOX()` etc) to accept `bbox` objects in addition to `sf*` objects. Also allows the `crs` argument of `BBOX()` to be a numeric EPSG code (not just character: `"EPSG:3005"`