### PR TITLE
add time_downloaded as attribute to bcdc_sf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,11 @@
 * Provide `as_tibble` as an alias for `collect` in line with `dbplyr` behaviour (#166)
 * When reading in excel files, `bcdc_get_data` now outputs a messages indicating the presence and names of any sheets (#190)
 * `bcdc_get_data()` & `bcdc_query_geodata()` will now work with full B.C. data catalogue url including resource (#125, #196)
+* `bcdc_sf` objects now have an `time_downloaded` attribute 
 
 ### BUG FIXES
 * Fix `select`, `filter` and `mutate` roxygen so that bcdata specific documentation to these methods is available
+* Add tests for attributes
 
 # bcdata 0.1.2
 

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -21,7 +21,7 @@ as.bcdc_sf <- function(x, query_list, url, full_url) {
   structure(x,
             class = c("bcdc_sf", setdiff(class(x), "bcdc_sf")),
             query_list = query_list,
-            url = url, full_url = full_url)
+            url = url, full_url = full_url, time_downloaded = Sys.time())
 }
 
 

--- a/tests/testthat/test-query-geodata-collect.R
+++ b/tests/testthat/test-query-geodata-collect.R
@@ -99,5 +99,5 @@ test_that("bcdc_sf objects has attributes",{
                      "url", "full_url", "time_downloaded"))
   expect_true(nzchar(attributes(sf_obj)$url))
   expect_true(nzchar(attributes(sf_obj)$full_url))
-  expect_true(nzchar(attributes(sf_obj)$time_downloaded))
+  expect_is(attributes(sf_obj)$time_downloaded, "POSIXt")
 })

--- a/tests/testthat/test-query-geodata-collect.R
+++ b/tests/testthat/test-query-geodata-collect.R
@@ -86,7 +86,7 @@ test_that("collect() returns a bcdc_sf object",{
   expect_s3_class(sf_obj, "bcdc_sf")
 })
 
-test_that("bcdc_sf objects have a url as an attributes",{
+test_that("bcdc_sf objects has attributes",{
   skip_on_cran()
   skip_if_net_down()
   sf_obj <- bcdc_query_geodata("76b1b7a3-2112-4444-857a-afccf7b20da8") %>%
@@ -94,5 +94,10 @@ test_that("bcdc_sf objects have a url as an attributes",{
     select(LATITUDE) %>%
     collect()
 
+  expect_identical(names(attributes(sf_obj)),
+                   c("names", "row.names", "class", "sf_column", "agr", "query_list",
+                     "url", "full_url", "time_downloaded"))
   expect_true(nzchar(attributes(sf_obj)$url))
+  expect_true(nzchar(attributes(sf_obj)$full_url))
+  expect_true(nzchar(attributes(sf_obj)$time_downloaded))
 })


### PR DESCRIPTION
This add when a layer is downloaded which is useful information no matter what. I also think that this could be useful for incorporating bcdata into bcmaps.