### PR TITLE
Make head/tail work with larger queries

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -39,7 +39,12 @@ print.bcdc_promise <- function(x, ...) {
 
   x$query_list$CQL_FILTER <- finalize_cql(x$query_list$CQL_FILTER)
 
-  query_list <- c(x$query_list, COUNT = 6)
+  if (is.null(x$query_list$count)) {
+    query_list <- c(x$query_list, count = 6) ## only add if not there.
+  } else {
+   query_list <- x$query_list
+  }
+
   cli <- x$cli
   cc <- cli$post(body = query_list, encode = "form")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,10 @@ compact <- function(l) Filter(Negate(is.null), l)
 
 bcdc_number_wfs_records <- function(query_list, client){
 
+  if (!is.null(query_list$count)) {
+    return(query_list$count)
+  }
+
   if(!is.null(query_list$propertyName)){
     query_list$propertyName <- NULL
   }

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -136,8 +136,9 @@ test_that("large vectors supplied to filter succeeds",{
     filter(WATERSHED_GROUP_CODE %in% "PORI") %>%
     collect()
 
-  expect_silent(bcdc_query_geodata(lines_record) %>%
-    filter(WATERSHED_KEY %in% pori$WATERSHED_KEY))
+  expect_is(bcdc_query_geodata(lines_record) %>%
+    filter(WATERSHED_KEY %in% pori$WATERSHED_KEY),
+    "bcdc_promise")
 
 })
 
@@ -212,9 +213,10 @@ test_that("an intersect with an object less than 5E5 proceeds",{
     st_as_sfc()
 
 
-  expect_silent(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
+  expect_is(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
     filter(WITHIN(small_districts)) %>%
-    collect())
+    collect(),
+    "bcdc_sf")
 })
 
 test_that("a BCGW name works with filter", {

--- a/tests/testthat/test-query-geodata-head-tail.R
+++ b/tests/testthat/test-query-geodata-head-tail.R
@@ -41,3 +41,20 @@ test_that("tail works", {
     tail(arrange(bcdc_get_data(record, resource = resource), .data[[col]]), 3L)[[col]]
   )
 })
+
+
+test_that("head/tail works with a record that would otherwise require pagination",{
+  skip_if_net_down()
+  skip_on_cran()
+  dh <- bcdc_query_geodata('2af1388e-d5f7-46dc-a6e2-f85415ddbd1c') %>%
+    head(3) %>%
+    collect()
+
+  expect_equal(nrow(dh), 3L)
+
+  dt <- bcdc_query_geodata('2af1388e-d5f7-46dc-a6e2-f85415ddbd1c') %>%
+    tail(3) %>%
+    collect()
+
+  expect_equal(nrow(dt), 3L)
+})

--- a/tests/testthat/test-query-geodata-select.R
+++ b/tests/testthat/test-query-geodata-select.R
@@ -64,19 +64,19 @@ test_that("select accept dplyr like column specifications",{
   skip_on_cran()
   layer <-  bcdc_query_geodata(polygon_record)
   wrong_fields <-  c('ADMIN_AREA_NAME', 'dummy_col')
-  correct_fields <-  c('ADMIN_AREA_NAME', 'OIC_YEAR')
+  correct_fields <-  c('ADMIN_AREA_NAME', 'OIC_MO_YEAR')
 
 
   ## Most basic select
-  expect_is(select(layer, ADMIN_AREA_NAME, OIC_YEAR), "bcdc_promise")
-  ## Using a pre-assigned vecotr
+  expect_is(select(layer, ADMIN_AREA_NAME, OIC_MO_YEAR), "bcdc_promise")
+  ## Using a pre-assigned vector
   expect_is(select(layer, correct_fields), "bcdc_promise")
   ## Throws an error when column doesn't exist
   expect_error(select(layer, wrong_fields))
-  expect_is(select(layer, ADMIN_AREA_NAME:OIC_YEAR), "bcdc_promise")
+  expect_is(select(layer, ADMIN_AREA_NAME:OIC_MO_YEAR), "bcdc_promise")
   ## Some weird mix
-  expect_is(select(layer, 'ADMIN_AREA_NAME', OIC_YEAR), "bcdc_promise")
+  expect_is(select(layer, 'ADMIN_AREA_NAME', OIC_MO_YEAR), "bcdc_promise")
   ## Another weird mix
-  expect_is(select(layer, c('ADMIN_AREA_NAME','OIC_YEAR') , OIC_NUMBER), "bcdc_promise")
+  expect_is(select(layer, c('ADMIN_AREA_NAME','OIC_MO_YEAR') , OIC_MO_NUMBER), "bcdc_promise")
   expect_is(select(layer, 1:5), "bcdc_promise")
 })


### PR DESCRIPTION
This PR fixes a bug that caused paginated requests to fail with `head`. For example this now works:

```  
dh <- bcdc_query_geodata('2af1388e-d5f7-46dc-a6e2-f85415ddbd1c') %>%
    head(3) %>%
    collect()
```
by telling the `bcdc_number_wfs_records` function to look out for a count parameter and use that if it exists. 

However, I am unable to make tail work. This does not currently work:

```  
dh <- bcdc_query_geodata('2af1388e-d5f7-46dc-a6e2-f85415ddbd1c') %>%
    tail(3) %>%
    collect()
```
As far as I can see, the _only_ difference is that a `tail` "query" includes a `startIndex` query parameter. I haven't yet been able to figure this out. 

`tail` _does_ work for a smaller query like this:

```
bcdc_query_geodata('hydrometric-stations-active-and-discontinued') %>% 
  tail(3) %>% 
  collect() 
```
