### PR TITLE
Respect users' "width" options settings by using strwrap and cat_line…

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -162,14 +162,15 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, verbose = TRUE, .
   # nocov start
 
   if (interactive() && verbose) {
-    cat("The record you are trying to access appears to have more than one resource.")
-    cat("\n Resources: \n")
+    cat_line_wrap("The record you are trying to access appears to have more than one resource.")
+    cat_line()
+    cat_line("Resources:")
 
     for (r in seq_len(nrow(resource_df))) {
       record_print_helper(resource_df[r, ], r)
     }
 
-    cat("--------\n")
+    cat_line("--------")
   }
 
   choices <- clean_wfs(resource_df$name)
@@ -185,8 +186,8 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, verbose = TRUE, .
 
   if (name_choice == "WFS request (Spatial Data)") {
     ## todo
-    # cat("To directly access this record in the future please use this command:\n")
-    # cat(glue::glue("bcdc_get_data('{x}', resource = '{id_choice}')"),"\n")
+    # cat_line_wrap("To directly access this record in the future please use this command:")
+    # cat_line_wrap(glue::glue("bcdc_get_data('{x}', resource = '{id_choice}')"))
     query <- bcdc_query_geodata(record = record_id, ...)
     return(collect(query))
   } else {


### PR DESCRIPTION
… in print methods

Old (printed full-width regardless of option):

    library(bcdata)

    options(width = 40)

    bcdc_search("airports")
    #> List of B.C. Data Catalogue Records
    #> 
    #> Number of records: 10
    #> Titles:
    #> 1: Airport Capacity and Service Information (other)
    #>  ID: 553a8c7c-bca2-4b92-b925-ef6085724092
    #>  Name: airport-capacity-and-service-information
    #> 2: BC Airports (other, xlsx, wms, kml)
    #>  ID: 76b1b7a3-2112-4444-857a-afccf7b20da8
    #>  Name: bc-airports
    #> 3: Customs Ports of Entry (other)
    #>  ID: 4fac3ad6-8749-4741-ac98-527b23e4b0b2
    #>  Name: customs-ports-of-entry
    #> 4: BC Wildfire Active Weather Stations (other, wms, kml)
    #>  ID: c16867a3-a7ac-4c07-9a3e-0325e66e29c0
    #>  Name: bc-wildfire-active-weather-stations
    #> 5: NTS BC Transport Points 1:250,000 - Digital Baseline Mapping (NTS) (other, wms, kml)
    #>  ID: 6ce711d4-5196-47fc-9bc0-0839b1aa2ca3
    #>  Name: nts-bc-transport-points-1-250-000-digital-baseline-mapping-nts
    #> 6: BC Transport Lines 1:2,000,000  (Digital Baseline Mapping) (wms, kml, other)
    #>  ID: fdd2370d-6a66-4c99-9ec8-ea5c99f81f64
    #>  Name: bc-transport-lines-1-2-000-000-digital-baseline-mapping
    #> 7: BC Transport Points 1:2,000,000  (Digital Baseline Mapping) (wms, kml, other)
    #>  ID: cf530cf2-c710-42cd-98df-afbe51c6982b
    #>  Name: bc-transport-points-1-2-000-000-digital-baseline-mapping
    #> 8: HelloBC Activities and Attractions Listing (other, wms, kml)
    #>  ID: 3a7dc21c-be34-4b33-adbe-fadd3aaba2d7
    #>  Name: hellobc-activities-and-attractions-listing
    #> 9: BC Climate Stations (other)
    #>  ID: d9c6cafe-0b24-4197-a91d-8448aa4d98c7
    #>  Name: bc-climate-stations
    #> 10: Sites Registry (Open Government Licence) (other, wms, kml)
    #>  ID: d5c6b8ed-c272-4c9e-8813-590a47b5c01c
    #>  Name: sites-registry-open-government-licence- 
    #> 
    #> Access a single record by calling bcdc_get_record(ID)
    #>       with the ID from the desired record.

    bcdc_get_record("bc-airports")
    #> Warning: It is advised to use the permanent id ('76b1b7a3-2112-4444-857a-afccf7b20da8') rather than the name of the record ('bc-airports') to guard against future name changes.
    #> B.C. Data Catalogue Record: BC Airports 
    #> 
    #> Name: bc-airports (ID: 76b1b7a3-2112-4444-857a-afccf7b20da8 )
    #> Permalink: https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8
    #> Sector: Natural Resources
    #> Licence: Open Government Licence - British Columbia
    #> Type: Geographic
    #> Last Updated: 2019-12-17 
    #> 
    #> Description: BC Airports identifies locations where aircraft may take-off and land. No guarantee
    #> is given that an identified point will be maintained to sufficient standards for
    #> landing and take-off of any/all aircraft.  It includes airports, aerodromes, water
    #> aerodromes, heliports, and airstrips. 
    #> 
    #> Resources: (4)
    #> # A tibble: 4 x 8
    #>   name  url   id    format ext  
    #>   <chr> <chr> <chr> <chr>  <chr>
    #> 1 BC G… http… 604c… other  ""   
    #> 2 BC_A… http… fccc… xlsx   "xls…
    #> 3 WMS … http… 4d03… wms    ""   
    #> 4 KML … http… 5b9f… kml    "kml"
    #> # … with 3 more variables:
    #> #   package_id <chr>, location <chr>,
    #> #   bcdata_available <lgl>
    #> 
    #> You can access the 'Resources' data frame using bcdc_tidy_resources()

<sup>Created on 2020-09-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

New (respects width option by wrapping at whitespace):

    library(bcdata)

    options(width = 40)

    bcdc_search("airports")
    #> List of B.C. Data Catalogue Records
    #> Number of records: 10
    #> Titles:
    #> 1: Airport Capacity and Service
    #>  Information (other)
    #>  ID:
    #>   553a8c7c-bca2-4b92-b925-ef6085724092
    #>  Name:
    #>   airport-capacity-and-service-information
    #> 2: BC Airports (other, xlsx, wms,
    #>  kml)
    #>  ID:
    #>   76b1b7a3-2112-4444-857a-afccf7b20da8
    #>  Name: bc-airports
    #> 3: Customs Ports of Entry (other)
    #>  ID:
    #>   4fac3ad6-8749-4741-ac98-527b23e4b0b2
    #>  Name: customs-ports-of-entry
    #> 4: BC Wildfire Active Weather
    #>  Stations (other, wms, kml)
    #>  ID:
    #>   c16867a3-a7ac-4c07-9a3e-0325e66e29c0
    #>  Name:
    #>   bc-wildfire-active-weather-stations
    #> 5: NTS BC Transport Points
    #>  1:250,000 - Digital Baseline
    #>  Mapping (NTS) (other, wms, kml)
    #>  ID:
    #>   6ce711d4-5196-47fc-9bc0-0839b1aa2ca3
    #>  Name:
    #>   nts-bc-transport-points-1-250-000-digital-baseline-mapping-nts
    #> 6: BC Transport Lines 1:2,000,000
    #>  (Digital Baseline Mapping) (wms,
    #>  kml, other)
    #>  ID:
    #>   fdd2370d-6a66-4c99-9ec8-ea5c99f81f64
    #>  Name:
    #>   bc-transport-lines-1-2-000-000-digital-baseline-mapping
    #> 7: BC Transport Points 1:2,000,000
    #>  (Digital Baseline Mapping) (wms,
    #>  kml, other)
    #>  ID:
    #>   cf530cf2-c710-42cd-98df-afbe51c6982b
    #>  Name:
    #>   bc-transport-points-1-2-000-000-digital-baseline-mapping
    #> 8: HelloBC Activities and
    #>  Attractions Listing (other, wms,
    #>  kml)
    #>  ID:
    #>   3a7dc21c-be34-4b33-adbe-fadd3aaba2d7
    #>  Name:
    #>   hellobc-activities-and-attractions-listing
    #> 9: BC Climate Stations (other)
    #>  ID:
    #>   d9c6cafe-0b24-4197-a91d-8448aa4d98c7
    #>  Name: bc-climate-stations
    #> 10: Sites Registry (Open Government
    #>  Licence) (other, wms, kml)
    #>  ID:
    #>   d5c6b8ed-c272-4c9e-8813-590a47b5c01c
    #>  Name:
    #>   sites-registry-open-government-licence-
    #> 
    #> Access a single record by calling
    #>  `bcdc_get_record(ID)` with the ID
    #>  from the desired record.

    bcdc_get_record("bc-airports")
    #> Warning: It is advised to use the permanent id ('76b1b7a3-2112-4444-857a-afccf7b20da8') rather than the name of the record ('bc-airports') to guard against future name changes.
    #> B.C. Data Catalogue Record: BC
    #>  Airports
    #> Name: bc-airports (ID:
    #>  76b1b7a3-2112-4444-857a-afccf7b20da8)
    #> Permalink:
    #>  https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8
    #> Sector: Natural Resources
    #> Licence: Open Government Licence -
    #>  British Columbia
    #> Type: Geographic
    #> Last Updated: 2019-12-17
    #> Description: BC Airports identifies
    #>  locations where aircraft may
    #>  take-off and land. No guarantee is
    #>  given that an identified point
    #>  will be maintained to sufficient
    #>  standards for landing and take-off
    #>  of any/all aircraft.  It includes
    #>  airports, aerodromes, water
    #>  aerodromes, heliports, and
    #>  airstrips.
    #> Resources: (4)
    #> # A tibble: 4 x 8
    #>   name  url   id    format ext  
    #>   <chr> <chr> <chr> <chr>  <chr>
    #> 1 BC G… http… 604c… other  ""   
    #> 2 BC_A… http… fccc… xlsx   "xls…
    #> 3 WMS … http… 4d03… wms    ""   
    #> 4 KML … http… 5b9f… kml    "kml"
    #> # … with 3 more variables:
    #> #   package_id <chr>, location <chr>,
    #> #   bcdata_available <lgl>
    #> You can access the 'Resources' data
    #>  frame using bcdc_tidy_resources()

<sup>Created on 2020-09-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>