### PR TITLE
Guard against check failures in examples

### DIFF
--- a/.github/workflows/cmd-check.yaml
+++ b/.github/workflows/cmd-check.yaml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         config:
         - { os: windows-latest, r: 'release', args: "'--no-manual'"}
-        - { os: macOS-latest,   r: 'release', args: "'--test-dontrun'"}
+        - { os: macOS-latest,   r: 'release', args: "'--as-cran'"}
         - { os: ubuntu-latest,   r: '3.5',     args: "'--no-manual'"}
         - { os: ubuntu-latest,   r: 'oldrel',  args: "'--no-manual'"}
-        - { os: ubuntu-latest,   r: 'release', args: "'--no-manual'"}
-        - { os: ubuntu-latest,   r: 'devel',   args: "c('--no-manual', '--test-dontrun')"}
+        - { os: ubuntu-latest,   r: 'release', args: "c('--no-manual', '--as-cran')"}
+        - { os: ubuntu-latest,   r: 'devel',   args: "c('--no-manual', '--as-cran')"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@
 ### MAINTENANCE
 * Updated internal SQL translation to use `DBI` S4 generics (`DBI::dbQuoteIdentifier()` is now used instead of 
   `dbplyr::sql_escape_ident()` and `DBI::dbQuoteString()` instead of `dbplyr::sql_escape_string()`), to comply 
-  with upcoming `dbplyr` 2.0 release (#225, #225; https://github.com/tidyverse/dbplyr/issues/385) 
+  with upcoming `dbplyr` 2.0 release (#225, #225; https://github.com/tidyverse/dbplyr/issues/385)
+* Wrapped all examples that call web resources in `try()` to avoid spurious check failures (#229).
 
 # bcdata 0.2.0
 

--- a/R/bcdc-web-services.R
+++ b/R/bcdc-web-services.R
@@ -40,31 +40,45 @@
 #'
 #' \donttest{
 #' # Returns a bcdc_promise, which can be further refined using filter/select:
-#' bcdc_query_geodata("bc-airports", crs = 3857)
+#' try(
+#'   bcdc_query_geodata("bc-airports", crs = 3857)
+#' )
 #'
 #' # To obtain the actual data as an sf object, collect() must be called:
-#' bcdc_query_geodata("bc-airports", crs = 3857) %>%
-#'   filter(PHYSICAL_ADDRESS == 'Victoria, BC') %>%
-#'   collect()
+#' try(
+#'   bcdc_query_geodata("bc-airports", crs = 3857) %>%
+#'     filter(PHYSICAL_ADDRESS == 'Victoria, BC') %>%
+#'     collect()
+#' )
 #'
-#' bcdc_query_geodata("groundwater-wells") %>%
-#'   filter(OBSERVATION_WELL_NUMBER == 108) %>%
-#'   select(WELL_TAG_NUMBER, INTENDED_WATER_USE) %>%
-#'   collect()
+#' try(
+#'   bcdc_query_geodata("groundwater-wells") %>%
+#'     filter(OBSERVATION_WELL_NUMBER == "108") %>%
+#'     select(WELL_TAG_NUMBER, INTENDED_WATER_USE) %>%
+#'     collect()
+#' )
 #'
 #' ## A moderately large layer
-#' bcdc_query_geodata("bc-environmental-monitoring-locations")
-#' bcdc_query_geodata("bc-environmental-monitoring-locations") %>%
-#'   filter(PERMIT_RELATIONSHIP == "DISCHARGE")
+#' try(
+#'   bcdc_query_geodata("bc-environmental-monitoring-locations")
+#' )
+#'
+#' try(
+#'   bcdc_query_geodata("bc-environmental-monitoring-locations") %>%
+#'     filter(PERMIT_RELATIONSHIP == "DISCHARGE")
+#' )
 #'
 #'
 #' ## A very large layer
-#' bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")
+#' try(
+#'   bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")
+#' )
 #'
 #' ## Using a BCGW name
-#' bcdc_query_geodata("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' try(
+#'   bcdc_query_geodata("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' )
 #' }
-#'
 #' @export
 bcdc_query_geodata <- function(record, crs = 3005) {
   if (!has_internet()) stop("No access to internet", call. = FALSE) # nocov
@@ -149,11 +163,18 @@ bcdc_query_geodata.bcdc_record <- function(record, crs = 3005) {
 #'
 #' @examples
 #' \donttest{
-#' bcdc_preview("regional-districts-legally-defined-administrative-areas-of-bc")
-#' bcdc_preview("points-of-well-diversion-applications")
+#' try(
+#'   bcdc_preview("regional-districts-legally-defined-administrative-areas-of-bc")
+#' )
+#'
+#' try(
+#'   bcdc_preview("points-of-well-diversion-applications")
+#' )
 #'
 #' # Using BCGW name
-#' bcdc_preview("WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP")
+#' try(
+#'   bcdc_preview("WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP")
+#' )
 #' }
 #' @export
 bcdc_preview <- function(record) { # nocov start

--- a/R/bcdc_browse.R
+++ b/R/bcdc_browse.R
@@ -30,16 +30,24 @@
 #' @examples
 #' \donttest{
 #' ## Take me to the B.C. Data Catalogue home page
-#' bcdc_browse()
+#' try(
+#'   bcdc_browse()
+#' )
 #'
 #' ## Take me to the B.C. airports catalogue record
-#' bcdc_browse("bc-airports")
+#' try(
+#'  bcdc_browse("bc-airports")\
+#' )
 #'
-#'#' ## Take me to the B.C. airports catalogue record
-#' bcdc_browse("76b1b7a3-2112-4444-857a-afccf7b20da8")
+#' ## Take me to the B.C. airports catalogue record
+#' try(
+#'   bcdc_browse("76b1b7a3-2112-4444-857a-afccf7b20da8")
+#' )
 #'
 #' ## Take me to the catalogue search results for 'fish'
-#' bcdc_browse("fish")
+#' try(
+#'  bcdc_browse("fish")
+#' )
 #'
 #' }
 bcdc_browse <- function(query = NULL, browser = getOption("browser"),

--- a/R/bcdc_browse.R
+++ b/R/bcdc_browse.R
@@ -36,7 +36,7 @@
 #'
 #' ## Take me to the B.C. airports catalogue record
 #' try(
-#'  bcdc_browse("bc-airports")\
+#'  bcdc_browse("bc-airports")
 #' )
 #'
 #' ## Take me to the B.C. airports catalogue record

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -30,20 +30,31 @@
 #' it is advisable to lower the chunk limit. Chunks must be less than 10000.
 #'
 #' @examples
+#' \donttest{
 #' ## Save initial conditions
-#' original_options <- options()
+#' try(
+#'   original_options <- options()
+#' )
 #'
 #' ## See initial options
-#' bcdc_options()
+#' try(
+#'   bcdc_options()
+#' )
 #'
-#' options(bcdata.max_geom_pred_size = 1E6)
+#' try(
+#'   options(bcdata.max_geom_pred_size = 1E6)
+#' )
 #'
 #' ## See updated options
-#' bcdc_options()
+#' try(
+#'   bcdc_options()
+#' )
 #'
 #' ## Reset initial conditions
-#' options(original_options)
-#'
+#' try(
+#'  options(original_options)
+#' )
+#' }
 #' @export
 
 bcdc_options <- function() {

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -21,7 +21,9 @@
 #'
 #' @examples
 #' \donttest{
-#' bcdc_search_facets("type")
+#' try(
+#'   bcdc_search_facets("type")
+#' )
 #' }
 bcdc_search_facets <- function(facet = c("license_id", "download_audience",
                                   "type", "res_format", "sector",
@@ -56,6 +58,12 @@ bcdc_search_facets <- function(facet = c("license_id", "download_audience",
 #'
 #' @return A character vector of the names of B.C. Data Catalogue records
 #' @export
+#' @examples
+#' \donttest{
+#' try(
+#'   bcdc_list()
+#' )
+#' }
 bcdc_list <- function() {
   if(!has_internet()) stop("No access to internet", call. = FALSE) # nocov
 
@@ -100,8 +108,13 @@ bcdc_list <- function() {
 #'
 #' @examples
 #' \donttest{
-#' bcdc_search("forest")
-#' bcdc_search("regional district", type = "Geographic", res_format = "fgdb")
+#' try(
+#'   bcdc_search("forest")
+#' )
+#'
+#' try(
+#'   bcdc_search("regional district", type = "Geographic", res_format = "fgdb")
+#' )
 #' }
 bcdc_search <- function(..., license_id = NULL,
                         download_audience = "Public",
@@ -178,10 +191,21 @@ bcdc_search <- function(..., license_id = NULL,
 #'
 #' @examples
 #' \donttest{
-#' bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports")
-#' bcdc_get_record("bc-airports")
-#' bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
-#' bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8")
+#' try(
+#'   bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports")
+#' )
+#'
+#' try(
+#'   bcdc_get_record("bc-airports")
+#' )
+#'
+#' try(
+#'   bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
+#' )
+#'
+#' try(
+#'   bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8")
+#' )
 #' }
 bcdc_get_record <- function(id) {
 
@@ -249,8 +273,13 @@ as.bcdc_recordlist <- function(x) {
 #'
 #' @examples
 #' \donttest{
-#' airports <- bcdc_get_record("bc-airports")
-#' bcdc_tidy_resources(airports)
+#' try(
+#'   airports <- bcdc_get_record("bc-airports")
+#' )
+#'
+#' try(
+#'   bcdc_tidy_resources(airports)
+#' )
 #' }
 #'
 #' @export

--- a/R/cql-geom-predicates.R
+++ b/R/cql-geom-predicates.R
@@ -48,8 +48,10 @@ CQL <- function(...) {
 #'
 #' @examples
 #' \donttest{
-#' airports <- bcdc_query_geodata("bc-airports") %>% collect()
-#' bcdc_cql_string(airports, "DWITHIN")
+#' try({
+#'   airports <- bcdc_query_geodata("bc-airports") %>% collect()
+#'   bcdc_cql_string(airports, "DWITHIN")
+#' })
 #' }
 #'
 #' @noRd

--- a/R/describe-feature.R
+++ b/R/describe-feature.R
@@ -28,8 +28,13 @@
 #'
 #' @examples
 #' \donttest{
-#'  bcdc_describe_feature("bc-airports")
-#'  bcdc_describe_feature("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' try(
+#'   bcdc_describe_feature("bc-airports")
+#' )
+#'
+#' try(
+#'   bcdc_describe_feature("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' )
 #' }
 #'
 #' @export

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -41,45 +41,68 @@
 #' @examples
 #' \donttest{
 #' # Using the record and resource ID:
-#' bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
-#'               resource = '4d0377d9-e8a1-429b-824f-0ce8f363512c')
-#' bcdc_get_data('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+#' try(
+#'   bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
+#'                 resource = '4d0377d9-e8a1-429b-824f-0ce8f363512c')
+#' )
+#'
+#' try(
+#'   bcdc_get_data('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+#' )
 #'
 #' # Using a `bcdc_record` object obtained from `bcdc_get_record`:
-#' record <- bcdc_get_record('1d21922b-ec4f-42e5-8f6b-bf320a286157')
-#' bcdc_get_data(record)
+#' try(
+#'   record <- bcdc_get_record('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+#' )
+#'
+#' try(
+#'   bcdc_get_data(record)
+#' )
 #'
 #' # Using a BCGW name
-#' bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' try(
+#'   bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+#' )
 #'
 #' # Using sf's sql querying ability
-#' bcdc_get_data(
-#'   record = '30aeb5c1-4285-46c8-b60b-15b1a6f4258b',
-#'   resource = '3d72cf36-ab53-4a2a-9988-a883d7488384',
-#'   layer = 'BC_Boundary_Terrestrial_Line',
-#'   query = "SELECT SHAPE_Length, geom FROM BC_Boundary_Terrestrial_Line WHERE SHAPE_Length < 100"
+#' try(
+#'   bcdc_get_data(
+#'     record = '30aeb5c1-4285-46c8-b60b-15b1a6f4258b',
+#'     resource = '3d72cf36-ab53-4a2a-9988-a883d7488384',
+#'     layer = 'BC_Boundary_Terrestrial_Line',
+#'     query = "SELECT SHAPE_Length, geom FROM BC_Boundary_Terrestrial_Line WHERE SHAPE_Length < 100"
+#'   )
 #' )
 #'
 #' ## Example of correcting import problems
 #'
 #' ## Some initial problems reading in the data
-#' bcdc_get_data('d7e6c8c7-052f-4f06-b178-74c02c243ea4')
+#' try(
+#'   bcdc_get_data('d7e6c8c7-052f-4f06-b178-74c02c243ea4')
+#' )
 #'
 #' ## From bcdc_get_record we realize that the data is in xlsx format
-#' bcdc_get_record('8620ce82-4943-43c4-9932-40730a0255d6')
+#' try(
+#'  bcdc_get_record('8620ce82-4943-43c4-9932-40730a0255d6')
+#' )
 #'
 #' ## bcdc_read_functions let's us know that bcdata
 #' ## uses readxl::read_excel to import xlsx files
-#' bcdc_read_functions()
+#' try(
+#'  bcdc_read_functions()
+#' )
 #'
 #' ## bcdata let's you know that this resource has
 #' ## multiple worksheets
-#' bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6')
+#' try(
+#'  bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6')
+#' )
 #'
 #' ## we can control what is read in from an excel file
 #' ## using arguments from readxl::read_excel
-#'
-#' bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = 'Regional Districts')
+#' try(
+#'   bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = 'Regional Districts')
+#' )
 #' }
 #'
 #' @export

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -183,13 +183,17 @@ print.bcdc_query <- function(x, ...) {
 #' @describeIn filter filter.bcdc_promise
 #' @examples
 #' \donttest{
+#' try(
 #'   crd <- bcdc_query_geodata("regional-districts-legally-defined-administrative-areas-of-bc") %>%
 #'     filter(ADMIN_AREA_NAME == "Cariboo Regional District") %>%
 #'     collect()
+#' )
 #'
-#' ret1 <- bcdc_query_geodata("fire-perimeters-historical") %>%
-#'   filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) %>%
-#'   collect()
+#' try(
+#'   ret1 <- bcdc_query_geodata("fire-perimeters-historical") %>%
+#'     filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) %>%
+#'     collect()
+#' )
 #'   }
 #' @export
 filter.bcdc_promise <- function(.data, ...) {
@@ -224,17 +228,26 @@ filter.bcdc_promise <- function(.data, ...) {
 #'
 #' @examples
 #' \donttest{
-#' feature_spec <- bcdc_describe_feature("bc-airports")
-#' ## Columns that can selected:
-#' feature_spec[feature_spec$sticky == TRUE,]
+#' try(
+#'   feature_spec <- bcdc_describe_feature("bc-airports")
+#' )
+#'
+#' try(
+#'   ## Columns that can selected:
+#'   feature_spec[feature_spec$sticky == TRUE,]
+#' )
 #'
 #' ## Select columns
-#' bcdc_query_geodata("bc-airports") %>%
-#'   select(DESCRIPTION, PHYSICAL_ADDRESS)
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'     select(DESCRIPTION, PHYSICAL_ADDRESS)
+#' )
 #'
 #' ## Select "sticky" columns
-#' bcdc_query_geodata("bc-airports") %>%
-#'   select(LOCALITY)
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'     select(LOCALITY)
+#' )
 #' }
 #'
 #'
@@ -297,8 +310,10 @@ tail.bcdc_promise <- function(x, n = 6L, ...) {
 #' \dontrun{
 #'
 #' ## Mutate columns
-#' bcdc_query_geodata("bc-airports") %>%
-#'   mutate(LATITUDE * 100)
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'     mutate(LATITUDE * 100)
+#' )
 #' }
 #'
 #'@export
@@ -324,11 +339,15 @@ mutate.bcdc_promise <- function(.data, ...){
 #'
 #' @examples
 #' \donttest{
-#' bcdc_query_geodata("bc-airports") %>%
-#'   collect()
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'     collect()
+#' )
 #'
-#' bcdc_query_geodata("bc-airports") %>%
-#'   as_tibble()
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'     as_tibble()
+#' )
 #' }
 #'
 collect.bcdc_promise <- function(x, ...){
@@ -409,9 +428,11 @@ as_tibble.bcdc_promise <- collect.bcdc_promise
 #' @export
 #' @examples
 #' \donttest{
-#' bcdc_query_geodata("bc-environmental-monitoring-locations") %>%
-#'   filter(PERMIT_RELATIONSHIP == "DISCHARGE") %>%
-#'   show_query()
+#' try(
+#'   bcdc_query_geodata("bc-environmental-monitoring-locations") %>%
+#'     filter(PERMIT_RELATIONSHIP == "DISCHARGE") %>%
+#'     show_query()
+#' )
 #'   }
 #'
 show_query.bcdc_promise <- function(x, ...) {
@@ -433,10 +454,14 @@ show_query.bcdc_promise <- function(x, ...) {
 #' @export
 #' @examples
 #' \donttest{
-#' air <- bcdc_query_geodata("bc-airports") %>%
-#'   collect()
+#' try(
+#'   air <- bcdc_query_geodata("bc-airports") %>%
+#'     collect()
+#' )
 #'
-#' show_query(air)
+#' try(
+#'   show_query(air)
+#' )
 #' }
 show_query.bcdc_sf <- function(x, ...) {
 

--- a/man/bcdc_browse.Rd
+++ b/man/bcdc_browse.Rd
@@ -43,16 +43,24 @@ the default
 \examples{
 \donttest{
 ## Take me to the B.C. Data Catalogue home page
-bcdc_browse()
+try(
+  bcdc_browse()
+)
 
 ## Take me to the B.C. airports catalogue record
-bcdc_browse("bc-airports")
+try(
+ bcdc_browse("bc-airports")\
+)
 
-#' ## Take me to the B.C. airports catalogue record
-bcdc_browse("76b1b7a3-2112-4444-857a-afccf7b20da8")
+## Take me to the B.C. airports catalogue record
+try(
+  bcdc_browse("76b1b7a3-2112-4444-857a-afccf7b20da8")
+)
 
 ## Take me to the catalogue search results for 'fish'
-bcdc_browse("fish")
+try(
+ bcdc_browse("fish")
+)
 
 }
 }

--- a/man/bcdc_browse.Rd
+++ b/man/bcdc_browse.Rd
@@ -49,7 +49,7 @@ try(
 
 ## Take me to the B.C. airports catalogue record
 try(
- bcdc_browse("bc-airports")\
+ bcdc_browse("bc-airports")
 )
 
 ## Take me to the B.C. airports catalogue record

--- a/man/bcdc_describe_feature.Rd
+++ b/man/bcdc_describe_feature.Rd
@@ -34,8 +34,13 @@ This can be a useful tool to examine a layer before issuing a query with \code{b
 }
 \examples{
 \donttest{
- bcdc_describe_feature("bc-airports")
- bcdc_describe_feature("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+try(
+  bcdc_describe_feature("bc-airports")
+)
+
+try(
+  bcdc_describe_feature("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+)
 }
 
 }

--- a/man/bcdc_get_data.Rd
+++ b/man/bcdc_get_data.Rd
@@ -40,45 +40,68 @@ Download and read a resource from a B.C. Data Catalogue record
 \examples{
 \donttest{
 # Using the record and resource ID:
-bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
-              resource = '4d0377d9-e8a1-429b-824f-0ce8f363512c')
-bcdc_get_data('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+try(
+  bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
+                resource = '4d0377d9-e8a1-429b-824f-0ce8f363512c')
+)
+
+try(
+  bcdc_get_data('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+)
 
 # Using a `bcdc_record` object obtained from `bcdc_get_record`:
-record <- bcdc_get_record('1d21922b-ec4f-42e5-8f6b-bf320a286157')
-bcdc_get_data(record)
+try(
+  record <- bcdc_get_record('1d21922b-ec4f-42e5-8f6b-bf320a286157')
+)
+
+try(
+  bcdc_get_data(record)
+)
 
 # Using a BCGW name
-bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+try(
+  bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+)
 
 # Using sf's sql querying ability
-bcdc_get_data(
-  record = '30aeb5c1-4285-46c8-b60b-15b1a6f4258b',
-  resource = '3d72cf36-ab53-4a2a-9988-a883d7488384',
-  layer = 'BC_Boundary_Terrestrial_Line',
-  query = "SELECT SHAPE_Length, geom FROM BC_Boundary_Terrestrial_Line WHERE SHAPE_Length < 100"
+try(
+  bcdc_get_data(
+    record = '30aeb5c1-4285-46c8-b60b-15b1a6f4258b',
+    resource = '3d72cf36-ab53-4a2a-9988-a883d7488384',
+    layer = 'BC_Boundary_Terrestrial_Line',
+    query = "SELECT SHAPE_Length, geom FROM BC_Boundary_Terrestrial_Line WHERE SHAPE_Length < 100"
+  )
 )
 
 ## Example of correcting import problems
 
 ## Some initial problems reading in the data
-bcdc_get_data('d7e6c8c7-052f-4f06-b178-74c02c243ea4')
+try(
+  bcdc_get_data('d7e6c8c7-052f-4f06-b178-74c02c243ea4')
+)
 
 ## From bcdc_get_record we realize that the data is in xlsx format
-bcdc_get_record('8620ce82-4943-43c4-9932-40730a0255d6')
+try(
+ bcdc_get_record('8620ce82-4943-43c4-9932-40730a0255d6')
+)
 
 ## bcdc_read_functions let's us know that bcdata
 ## uses readxl::read_excel to import xlsx files
-bcdc_read_functions()
+try(
+ bcdc_read_functions()
+)
 
 ## bcdata let's you know that this resource has
 ## multiple worksheets
-bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6')
+try(
+ bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6')
+)
 
 ## we can control what is read in from an excel file
 ## using arguments from readxl::read_excel
-
-bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = 'Regional Districts')
+try(
+  bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = 'Regional Districts')
+)
 }
 
 }

--- a/man/bcdc_get_record.Rd
+++ b/man/bcdc_get_record.Rd
@@ -25,9 +25,20 @@ Show a single B.C. Data Catalogue record
 }
 \examples{
 \donttest{
-bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports")
-bcdc_get_record("bc-airports")
-bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
-bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8")
+try(
+  bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports")
+)
+
+try(
+  bcdc_get_record("bc-airports")
+)
+
+try(
+  bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
+)
+
+try(
+  bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8")
+)
 }
 }

--- a/man/bcdc_list.Rd
+++ b/man/bcdc_list.Rd
@@ -12,3 +12,10 @@ A character vector of the names of B.C. Data Catalogue records
 \description{
 Return a full list of the names of B.C. Data Catalogue records
 }
+\examples{
+\donttest{
+try(
+  bcdc_list()
+)
+}
+}

--- a/man/bcdc_options.Rd
+++ b/man/bcdc_options.Rd
@@ -26,18 +26,29 @@ requested. On faster internet connections, a bigger chunk limit could be useful 
 it is advisable to lower the chunk limit. Chunks must be less than 10000.
 }
 \examples{
+\donttest{
 ## Save initial conditions
-original_options <- options()
+try(
+  original_options <- options()
+)
 
 ## See initial options
-bcdc_options()
+try(
+  bcdc_options()
+)
 
-options(bcdata.max_geom_pred_size = 1E6)
+try(
+  options(bcdata.max_geom_pred_size = 1E6)
+)
 
 ## See updated options
-bcdc_options()
+try(
+  bcdc_options()
+)
 
 ## Reset initial conditions
-options(original_options)
-
+try(
+ options(original_options)
+)
+}
 }

--- a/man/bcdc_preview.Rd
+++ b/man/bcdc_preview.Rd
@@ -23,10 +23,17 @@ Get map from the B.C. Web Service
 }
 \examples{
 \donttest{
-bcdc_preview("regional-districts-legally-defined-administrative-areas-of-bc")
-bcdc_preview("points-of-well-diversion-applications")
+try(
+  bcdc_preview("regional-districts-legally-defined-administrative-areas-of-bc")
+)
+
+try(
+  bcdc_preview("points-of-well-diversion-applications")
+)
 
 # Using BCGW name
-bcdc_preview("WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP")
+try(
+  bcdc_preview("WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP")
+)
 }
 }

--- a/man/bcdc_query_geodata.Rd
+++ b/man/bcdc_query_geodata.Rd
@@ -45,29 +45,43 @@ object with \code{\link[=collect]{collect()}}. See examples.
 
 \donttest{
 # Returns a bcdc_promise, which can be further refined using filter/select:
-bcdc_query_geodata("bc-airports", crs = 3857)
+try(
+  bcdc_query_geodata("bc-airports", crs = 3857)
+)
 
 # To obtain the actual data as an sf object, collect() must be called:
-bcdc_query_geodata("bc-airports", crs = 3857) \%>\%
-  filter(PHYSICAL_ADDRESS == 'Victoria, BC') \%>\%
-  collect()
+try(
+  bcdc_query_geodata("bc-airports", crs = 3857) \%>\%
+    filter(PHYSICAL_ADDRESS == 'Victoria, BC') \%>\%
+    collect()
+)
 
-bcdc_query_geodata("groundwater-wells") \%>\%
-  filter(OBSERVATION_WELL_NUMBER == 108) \%>\%
-  select(WELL_TAG_NUMBER, INTENDED_WATER_USE) \%>\%
-  collect()
+try(
+  bcdc_query_geodata("groundwater-wells") \%>\%
+    filter(OBSERVATION_WELL_NUMBER == "108") \%>\%
+    select(WELL_TAG_NUMBER, INTENDED_WATER_USE) \%>\%
+    collect()
+)
 
 ## A moderately large layer
-bcdc_query_geodata("bc-environmental-monitoring-locations")
-bcdc_query_geodata("bc-environmental-monitoring-locations") \%>\%
-  filter(PERMIT_RELATIONSHIP == "DISCHARGE")
+try(
+  bcdc_query_geodata("bc-environmental-monitoring-locations")
+)
+
+try(
+  bcdc_query_geodata("bc-environmental-monitoring-locations") \%>\%
+    filter(PERMIT_RELATIONSHIP == "DISCHARGE")
+)
 
 
 ## A very large layer
-bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")
+try(
+  bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")
+)
 
 ## Using a BCGW name
-bcdc_query_geodata("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+try(
+  bcdc_query_geodata("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW")
+)
 }
-
 }

--- a/man/bcdc_search.Rd
+++ b/man/bcdc_search.Rd
@@ -43,7 +43,12 @@ Search the B.C. Data Catalogue
 }
 \examples{
 \donttest{
-bcdc_search("forest")
-bcdc_search("regional district", type = "Geographic", res_format = "fgdb")
+try(
+  bcdc_search("forest")
+)
+
+try(
+  bcdc_search("regional district", type = "Geographic", res_format = "fgdb")
+)
 }
 }

--- a/man/bcdc_search_facets.Rd
+++ b/man/bcdc_search_facets.Rd
@@ -22,6 +22,8 @@ Get the valid values for a facet (that you can use in \code{\link[=bcdc_search]{
 }
 \examples{
 \donttest{
-bcdc_search_facets("type")
+try(
+  bcdc_search_facets("type")
+)
 }
 }

--- a/man/bcdc_tidy_resources.Rd
+++ b/man/bcdc_tidy_resources.Rd
@@ -28,8 +28,13 @@ useful information on the formats, availability and types of data available.
 }
 \examples{
 \donttest{
-airports <- bcdc_get_record("bc-airports")
-bcdc_tidy_resources(airports)
+try(
+  airports <- bcdc_get_record("bc-airports")
+)
+
+try(
+  bcdc_tidy_resources(airports)
+)
 }
 
 }

--- a/man/collect-methods.Rd
+++ b/man/collect-methods.Rd
@@ -26,11 +26,15 @@ See \code{dplyr::\link[dplyr:compute]{collect}} for details.
 }
 \examples{
 \donttest{
-bcdc_query_geodata("bc-airports") \%>\%
-  collect()
+try(
+  bcdc_query_geodata("bc-airports") \%>\%
+    collect()
+)
 
-bcdc_query_geodata("bc-airports") \%>\%
-  as_tibble()
+try(
+  bcdc_query_geodata("bc-airports") \%>\%
+    as_tibble()
+)
 }
 
 }

--- a/man/filter.Rd
+++ b/man/filter.Rd
@@ -30,13 +30,17 @@ See \code{dplyr::\link[dplyr]{filter}} for details.
 
 \examples{
 \donttest{
+try(
   crd <- bcdc_query_geodata("regional-districts-legally-defined-administrative-areas-of-bc") \%>\%
     filter(ADMIN_AREA_NAME == "Cariboo Regional District") \%>\%
     collect()
+)
 
-ret1 <- bcdc_query_geodata("fire-perimeters-historical") \%>\%
-  filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) \%>\%
-  collect()
+try(
+  ret1 <- bcdc_query_geodata("fire-perimeters-historical") \%>\%
+    filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) \%>\%
+    collect()
+)
   }
 }
 \keyword{internal}

--- a/man/mutate.Rd
+++ b/man/mutate.Rd
@@ -28,8 +28,10 @@ See \code{dplyr::\link[dplyr]{mutate}} for details.
 \dontrun{
 
 ## Mutate columns
-bcdc_query_geodata("bc-airports") \%>\%
-  mutate(LATITUDE * 100)
+try(
+  bcdc_query_geodata("bc-airports") \%>\%
+    mutate(LATITUDE * 100)
+)
 }
 
 }

--- a/man/select.Rd
+++ b/man/select.Rd
@@ -28,17 +28,26 @@ See \code{dplyr::\link[dplyr]{select}} for details.
 
 \examples{
 \donttest{
-feature_spec <- bcdc_describe_feature("bc-airports")
-## Columns that can selected:
-feature_spec[feature_spec$sticky == TRUE,]
+try(
+  feature_spec <- bcdc_describe_feature("bc-airports")
+)
+
+try(
+  ## Columns that can selected:
+  feature_spec[feature_spec$sticky == TRUE,]
+)
 
 ## Select columns
-bcdc_query_geodata("bc-airports") \%>\%
-  select(DESCRIPTION, PHYSICAL_ADDRESS)
+try(
+  bcdc_query_geodata("bc-airports") \%>\%
+    select(DESCRIPTION, PHYSICAL_ADDRESS)
+)
 
 ## Select "sticky" columns
-bcdc_query_geodata("bc-airports") \%>\%
-  select(LOCALITY)
+try(
+  bcdc_query_geodata("bc-airports") \%>\%
+    select(LOCALITY)
+)
 }
 
 

--- a/man/show_query.Rd
+++ b/man/show_query.Rd
@@ -27,16 +27,22 @@ See \code{dplyr::\link[dplyr:explain]{show_query}} for details.
 
 \examples{
 \donttest{
-bcdc_query_geodata("bc-environmental-monitoring-locations") \%>\%
-  filter(PERMIT_RELATIONSHIP == "DISCHARGE") \%>\%
-  show_query()
+try(
+  bcdc_query_geodata("bc-environmental-monitoring-locations") \%>\%
+    filter(PERMIT_RELATIONSHIP == "DISCHARGE") \%>\%
+    show_query()
+)
   }
 
 \donttest{
-air <- bcdc_query_geodata("bc-airports") \%>\%
-  collect()
+try(
+  air <- bcdc_query_geodata("bc-airports") \%>\%
+    collect()
+)
 
-show_query(air)
+try(
+  show_query(air)
+)
 }
 }
 \keyword{internal}


### PR DESCRIPTION
Set up GH Actions to run the examples that are wrapped in `donttest{}`

Files to be checked for examples that hit the web services, and wrap those in `try()`:

- [x] bcdata-package.R
- [x] bcdc_browse.R
- [x] bcdc_options.R
- [x] bcdc_search.R
- [x] bcdc-web-services.R
- [x] cql-geom-predicates.R
- [x] cql-translator.R
- [x] describe-feature.R
- [x] get_data.R
- [x] utils-as_tibble.R
- [x] utils-classes.R
- [x] utils-collect.R
- [x] utils-filter.R
- [x] utils-is.R
- [x] utils-mutate.R
- [x] utils-pipe.R
- [x] utils-select.R
- [x] utils-show-query.R
- [x] utils.R
- [x] zzz.R