### PR TITLE
fix parameter in methods

### DIFF
--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -403,7 +403,7 @@ collect.bcdc_promise <- function(x, ...){
       limit_param = "count",
       offset_param = "startIndex",
       limit = number_of_records,
-      limit_chunk = getOption("bcdata.chunk-limit", default = 1000),
+      chunk = getOption("bcdata.chunk-limit", default = 1000),
       progress = interactive()
     )
 

--- a/tests/testthat/test-utils-classes.R
+++ b/tests/testthat/test-utils-classes.R
@@ -1,0 +1,11 @@
+test_that("Paginator instantiation did not change fields name", {
+
+  # Used fields in collect.bcdc_promise
+  expect_true(
+    all(
+      c("by", "limit_param", "offset_param", "limit",
+        "chunk", "progress") %in% names(crul::Paginator$public_fields)
+    )
+  )
+
+})


### PR DESCRIPTION
Parameter name `limit_chunk` does not match `chunk` in `?crul::Paginator` documentation.

```r
library(bcdata)
bec <- bcdc_get_data(bcdc_search("BEC Map")[[1]])
```

Current call to `Paginator$new` will complain about parameter `limit_chunk` being unused.

I check `crul` commits history, and they changed `limit_chunk` to `chunk` 6 months ago.

Great package. Godspeed.