### PR TITLE
Fix potential onLoad failure from getCapabilities call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # bcdata (development version)
 
-* Code in `.onLoad()` that sent a request to the wfs getCapabilities endpoint could cause the package to fail to load. This was moved into a function that makes the request the first time it's required, and stores the result for the remainder of the session (#271)
+* Code in `.onLoad()` that sent a request to the wfs getCapabilities endpoint could cause the package to fail to load. This was moved into an internal function `bcdc_get_capabilities()` that makes the request the first time it's required, and stores the result for the remainder of the session (#271)
 
 # bcdata 0.2.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bcdata (development version)
 
+* Code in `.onLoad()` that sent a request to the wfs getCapabilities endpoint could cause the package to fail to load. This was moved into a function that makes the request the first time it's required, and stores the result for the remainder of the session (#271)
+
 # bcdata 0.2.3
 
 ### IMPROVEMENTS

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -89,7 +89,7 @@ check_chunk_limit <- function(){
   }
 }
 
-bcdc_get_wfs_records_xml <- function() {
+bcdc_get_capabilites <- function() {
   current_xml <- ._bcdataenv_$get_capabilities_xml
   if (!is.null(current_xml) && inherits(current_xml, "xml_document")) {
     # Already retrieved and stored this session
@@ -117,7 +117,7 @@ bcdc_get_wfs_records_xml <- function() {
 }
 
 bcdc_get_wfs_records <- function() {
-  doc <- bcdc_get_wfs_records_xml()
+  doc <- bcdc_get_capabilites()
 
   if (is.null(doc)) stop("Unable to access wfs record listing", call. = FALSE)
 
@@ -132,7 +132,7 @@ bcdc_get_wfs_records <- function() {
 }
 
 bcdc_single_download_limit <- function() {
-  doc <- bcdc_get_wfs_records_xml()
+  doc <- bcdc_get_capabilites()
 
   if (is.null(doc)) {
     message("Unable to access wfs record listing, using default download limit of 10000")

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -89,7 +89,7 @@ check_chunk_limit <- function(){
   }
 }
 
-bcdc_get_capabilites <- function() {
+bcdc_get_capabilities <- function() {
   current_xml <- ._bcdataenv_$get_capabilities_xml
   if (!is.null(current_xml) && inherits(current_xml, "xml_document")) {
     # Already retrieved and stored this session
@@ -117,7 +117,7 @@ bcdc_get_capabilites <- function() {
 }
 
 bcdc_get_wfs_records <- function() {
-  doc <- bcdc_get_capabilites()
+  doc <- bcdc_get_capabilities()
 
   if (is.null(doc)) stop("Unable to access wfs record listing", call. = FALSE)
 
@@ -132,7 +132,7 @@ bcdc_get_wfs_records <- function() {
 }
 
 bcdc_single_download_limit <- function() {
-  doc <- bcdc_get_capabilites()
+  doc <- bcdc_get_capabilities()
 
   if (is.null(doc)) {
     message("Unable to access wfs record listing, using default download limit of 10000")

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -112,7 +112,6 @@ bcdc_get_wfs_records_xml <- function() {
     ._bcdataenv_$get_capabilities_xml <- ret
     return(ret)
   } else {
-    message("Unable to access wfs record listing")
     invisible(NULL)
   }
 }
@@ -136,6 +135,7 @@ bcdc_single_download_limit <- function() {
   doc <- bcdc_get_wfs_records_xml()
 
   if (is.null(doc)) {
+    message("Unable to access wfs record listing, using default download limit of 10000")
     return(10000L)
   }
 

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -84,12 +84,18 @@ check_chunk_limit <- function(){
   chunk_value <- getOption("bcdata.chunk_limit")
   chunk_limit <- getOption("bcdata.single_download_limit", default = bcdc_single_download_limit())
 
-  if(!is.null(chunk_value) && chunk_value >= chunk_limit){
+  if (!is.null(chunk_value) && chunk_value >= chunk_limit){
     stop(glue::glue("Your chunk value of {chunk_value} exceed the BC Data Catalogue chunk limit of {chunk_limit}"), call. = FALSE)
   }
 }
 
 bcdc_get_wfs_records_xml <- function() {
+  current_xml <- ._bcdataenv_$get_capabilities_xml
+  if (!is.null(current_xml) && inherits(current_xml, "xml_document")) {
+    # Already retrieved and stored this session
+    return(current_xml)
+  }
+
   if (has_internet()) {
     url <- "http://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=Getcapabilities"
     cli <- bcdc_http_client(url, auth = FALSE)
@@ -101,22 +107,20 @@ bcdc_get_wfs_records_xml <- function() {
     ))
 
     res <- cc$parse("UTF-8")
-    xml2::read_xml(res)
-
+    ret <- xml2::read_xml(res)
+    # store it and return it
+    ._bcdataenv_$get_capabilities_xml <- ret
+    return(ret)
   } else {
-    message("No access to internet")
+    message("Unable to access wfs record listing")
     invisible(NULL)
   }
 }
 
 bcdc_get_wfs_records <- function() {
-  doc <- ._bcdataenv_$get_capabilities_xml
+  doc <- bcdc_get_wfs_records_xml()
 
-  if (is.null(doc)) {
-    # Try again to get the xml
-    doc <- ._bcdataenv_$get_capabilities_xml <- suppressMessages(bcdc_get_wfs_records_xml())
-    if (is.null(doc)) stop("No access to internet", call. = FALSE)
-  }
+  if (is.null(doc)) stop("Unable to access wfs record listing", call. = FALSE)
 
   # d1 is the default xml namespace (see xml2::xml_ns(doc))
   features <- xml2::xml_find_all(doc, "./d1:FeatureTypeList/d1:FeatureType")
@@ -129,10 +133,9 @@ bcdc_get_wfs_records <- function() {
 }
 
 bcdc_single_download_limit <- function() {
-  doc <- ._bcdataenv_$get_capabilities_xml
+  doc <- bcdc_get_wfs_records_xml()
 
   if (is.null(doc)) {
-    message("No access to internet")
     return(10000L)
   }
 

--- a/R/bcdc_search.R
+++ b/R/bcdc_search.R
@@ -68,7 +68,9 @@ bcdc_list_groups <- function() bcdc_search_facets("groups")
 #' @export
 #' @examples
 #' \donttest{
-#' bcdc_list_group_records('environmental-reporting-bc')
+#' try(
+#'   bcdc_list_group_records('environmental-reporting-bc')
+#' )
 #' }
 
 bcdc_list_group_records <- function(group) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@
 
 .onLoad <- function(...) {
   ._bcdataenv_$named_get_record_warned <- FALSE # nocov
-  ._bcdataenv_$get_capabilities_xml <- bcdc_get_wfs_records_xml() # nocov
+  ._bcdataenv_$get_capabilities_xml <- NULL # nocov
 
 }
 

--- a/man/bcdc_list_group_records.Rd
+++ b/man/bcdc_list_group_records.Rd
@@ -23,6 +23,8 @@ https://catalogue.data.gov.bc.ca/group or accessed directly from R using \code{b
 
 \examples{
 \donttest{
-bcdc_list_group_records('environmental-reporting-bc')
+try(
+  bcdc_list_group_records('environmental-reporting-bc')
+)
 }
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,17 +1,17 @@
 # Copyright 2019 Province of British Columbia
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-library(testthat)
-library(bcdata)
-library(sf)
-
-test_check("bcdata")
+if (require("testthat", quietly = TRUE)) {
+  library(bcdata)
+  library(sf)
+  test_check("bcdata")
+}

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -24,6 +24,7 @@ test_that("bcdata.chunk_limit",{
 })
 
 test_that("bcdata.single_download_limit", {
+  skip_if_net_down()
   skip_on_cran()
   withr::local_options(list(bcdata.single_download_limit = 1))
   expect_message(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -56,3 +56,18 @@ test_that("is_whse_object_name works", {
   expect_false(is_whse_object_name("foo"))
   expect_false(is_whse_object_name(structure(list(), class = "bcdc_record")))
 })
+
+test_that("bcdc_get_capabilities works", {
+  skip_on_cran()
+  skip_if_net_down()
+
+  old_get_caps <- ._bcdataenv_$get_capabilities_xml
+
+  on.exit(
+    ._bcdataenv_$get_capabilities_xml <- old_get_caps
+  )
+
+  ._bcdataenv_$get_capabilities_xml <- NULL
+  expect_is(bcdc_get_capabilities(), "xml_document")
+  expect_equal(bcdc_get_capabilities(), ._bcdataenv_$get_capabilities_xml)
+})


### PR DESCRIPTION
See warning: https://www.r-project.org/nosvn/R.check/r-patched-solaris-x86/bcdata-00check.html

- Remove bcdc_get_wfs_records_xml from onLoad:
    - set get_capabilities_xml to NULL on pkg load
    - bcdc_get_wfs_records_xml() retrieves xml on first request and store for rest of the session
    - eliminate some redundant messages
- Wrap example in try(), add missing skip_if_net_down()
