### PR TITLE
Fail informatively when resource doesn't exist

### DIFF
--- a/.github/workflows/cmd-check.yaml
+++ b/.github/workflows/cmd-check.yaml
@@ -18,7 +18,6 @@ jobs:
         config:
         - { os: windows-latest, r: 'release', args: "'--no-manual'"}
         - { os: macOS-latest,   r: 'release', args: "'--no-manual'"}
-        - { os: macOS-latest,   r: 'oldrel',  args: "'--no-manual'"}
         - { os: ubuntu-18.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", args: "'--no-manual'"}
         - { os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", args: "'--no-manual'"}
         - { os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", args: "''"}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # bcdata (development version)
-* Added `bcdc_get_citation` to generate bibliographic entries (via `utils::bibentry`) for individuals records. #273
 
+* Added `bcdc_get_citation` to generate bibliographic entries (via `utils::bibentry`) for individuals records. #273
 * Results from `bcdc_search()` (objects of class `"bcdc_recordlist"`) now print 50 records by default, instead of 10. In addition, there is a new `[` method for `"bcdc_recordlist"` objects, allowing you to subset these lists and still have a nice printout (#288).
+* Ensure that `bcdc_get_data()` fails informatively when a given resource doesn't exist in a record (#290)
+
 
 # bcdata 0.3.0
 

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -169,6 +169,9 @@ bcdc_get_data.bcdc_record <- function(record, resource = NULL, verbose = TRUE, .
 
   ## non-wms; resource specified
   if (!is.null(resource)) {
+    if (!resource %in% resource_df$id) {
+      stop("The specified resource does not exist in this record", call. = FALSE)
+    }
     return(read_from_url(resource_df[resource_df$id == resource, , drop = FALSE],
                          ...))
   }

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -96,7 +96,7 @@ test_that("fails when resource doesn't exist", {
   skip_if_net_down()
   skip_on_cran()
   expect_error(bcdc_get_data("300c0980-b5e3-4202-b0da-d816f14fadad",
-                             resource = "4bc42b04-f126-4f91-90de-804b27cd51f2"),
+                             resource = "not-a-real-resource"),
                "The specified resource does not exist in this record")
 })
 

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -92,11 +92,19 @@ test_that("unknown single file (shp) inside zip", {
             "sf")
 })
 
-test_that("fails when multiple files in a zip", {
+test_that("fails when resource doesn't exist", {
   skip_if_net_down()
   skip_on_cran()
   expect_error(bcdc_get_data("300c0980-b5e3-4202-b0da-d816f14fadad",
                              resource = "4bc42b04-f126-4f91-90de-804b27cd51f2"),
+               "The specified resource does not exist in this record")
+})
+
+test_that("fails when multiple files in a zip", {
+  skip_if_net_down()
+  skip_on_cran()
+  expect_error(bcdc_get_data("300c0980-b5e3-4202-b0da-d816f14fadad",
+                             resource = "c212a8a7-c625-4464-b9c8-4527c843f52f"),
                "More than one supported file in zip file")
 })
 


### PR DESCRIPTION
Tests are currently failing because one of our test records changed the resource id. This illustrated that we don't actually have a check to ensure a requested resource exists in a record. This fixes that (along with a new test), and fixes the failing test by using the new resource ID.