### PR TITLE
S3 generic/method consistency

### DIFF
--- a/R/cql-translator.R
+++ b/R/cql-translator.R
@@ -149,7 +149,7 @@ wfs_con <- structure(
 #' @keywords internal
 #' @importFrom dbplyr sql_translation
 #' @export
-sql_translation.wfsConnection <- function(conn) {
+sql_translation.wfsConnection <- function(con) {
   dbplyr::sql_variant(
     cql_scalar,
     cql_agg,


### PR DESCRIPTION
Fixes CRAN check NOTE at: https://cran.r-project.org/web/checks/check_results_bcdata.html. The `dbplyr` generic `sql_translation()` has argument name `con`, we had `conn`