### PR TITLE
use new citation style

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,15 +1,12 @@
-citHeader("To cite bcdata in publications please use:")
-
 bibentry(
   "Article",
   doi = "10.21105/joss.02927",
-  year = {2021},
+  year = 2021,
   publisher = "The Open Journal",
-  volume = {6},
-  number = {61},
-  pages = {2927},
+  volume = 6,
+  number = 61,
+  pages = 2927,
   author = "Andrew C. Teucher and Sam J. Albers and Stephanie L. Hazlitt",
   title = "bcdata: An R package for searching and retrieving data from the B.C. Data Catalogue",
-  journal = "Journal of Open Source Software",
-  textVersion = "Teucher et al., (2021). bcdata: An R package for searching and retrieving data from the B.C. Data Catalogue. Journal of Open Source Software, 6(61), 2927, https://doi.org/10.21105/joss.02927"
+  journal = "Journal of Open Source Software"
 )


### PR DESCRIPTION
CRAN wants people to use the [newer citation format `bibentry()`](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#CITATION-files), else we may get this NOTE:

```
Package CITATION file contains call(s) to citEntry(), citHeader() or
   citFooter().  Please use bibentry() instead.
```