### PR TITLE
Reconcile chunk_limit and single_download_limit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,7 +56,7 @@ Suggests:
     ggplot2,
     knitr,
     rmarkdown,
-    testthat,
+    testthat (>= 3.0.0),
     withr
 VignetteBuilder: 
     knitr
@@ -86,3 +86,4 @@ Collate:
     'utils-show-query.R'
     'utils.R'
     'zzz.R'
+Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bcdata (development version)
 
+* Deprecate the `bcdata.single_download_limit` option, as it was mostly redundant with `bcdata.chunk_limit`, and should always be set by the server. Please set the page size limit for paginated requests via the `bcdata.chunk_limit` option (#332)
+
 # bcdata 0.4.1
 
 * Add `jsonlite::read_json()` as a file read method, so users can now download & read `json` resources in B.C. Data Catalogue records

--- a/R/bcdc-web-services.R
+++ b/R/bcdc-web-services.R
@@ -18,8 +18,7 @@
 #' `"wms"` in the `format` column it is available as a Web
 #' Feature Service, and you can query and download it
 #' using `bcdc_query_geodata()`. The response will be
-#' paginated if the number of features is above the number
-#' set by the `bcdata.single_download_limit` option.
+#' paginated if the number of features is greater than that allowed by the server.
 #' Please see [bcdc_options()] for defaults and more
 #' information.
 #'

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -17,7 +17,7 @@
 #' option})`. The default options are purposefully set conservatively to
 #' hopefully ensure successful requests. Resetting these options may result in
 #' failed calls to the data catalogue. Options in R are reset every time R is
-#' re-started. See examples for addition ways to restore your initial state.
+#' re-started. See examples for additional ways to restore your initial state.
 #'
 #' `bcdata.max_geom_pred_size` is the maximum size in bytes of an object used
 #' for a geometric operation. Objects that are bigger than this value will have

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -23,7 +23,7 @@
 #' for a geometric operation. Objects that are bigger than this value will have
 #' a bounding box drawn and apply the geometric operation on that simpler
 #' polygon. The [bcdc_check_geom_size] function can be used to assess whether a
-#' given spatial object exceed the value of this option. Users can iteratively
+#' given spatial object exceeds the value of this option. Users can iteratively
 #' try to increase the maximum geometric predicate size and see if the bcdata
 #' catalogue accepts the request.
 #'

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -28,12 +28,12 @@
 #' from the catalogue, the request is broken up into smaller chunks which are then recombined after they've
 #' been downloaded. This is called "pagination". bcdata does this all for you but using this option you can set the size of the chunk
 #' requested. On faster internet connections, a bigger chunk limit could be useful while on slower connections,
-#' it is advisable to lower the chunk limit. Chunks must be less than 10000.
+#' it is advisable to lower the chunk limit. The default is the same as `bcdata.single_download_limit`.
 #'
 #' `bcdata.single_download_limit` is the maximum number of records an object can be before forcing a paginated download
 #' (see entry for `bcdata.chunk_limit` for details on pagination).
 #' Tweaking this option in conjunction with `bcdata.chunk_limit` can often resolve failures in large and complex downloads.
-#' The default is 10000 records.
+#' The default is obtained from the server.
 #'
 #' @examples
 #' \donttest{
@@ -69,24 +69,26 @@ bcdc_options <- function() {
     ifelse(is.null(x), NA, as.numeric(x))
   }
 
+  single_download_limit <- bcdc_single_download_limit()
+
   dplyr::tribble(
     ~ option, ~ value, ~default,
     "bcdata.max_geom_pred_size", null_to_na(getOption("bcdata.max_geom_pred_size")), 5E5,
-    "bcdata.chunk_limit", null_to_na(getOption("bcdata.chunk_limit")), 1000,
+    "bcdata.chunk_limit", null_to_na(getOption("bcdata.chunk_limit")), single_download_limit,
     "bcdata.single_download_limit",
-    null_to_na(getOption("bcdata.single_download_limit",
-                         default = bcdc_single_download_limit())), 10000
+    null_to_na(getOption("bcdata.single_download_limit")), single_download_limit
   )
 }
 
 
 check_chunk_limit <- function(){
-  chunk_value <- getOption("bcdata.chunk_limit")
+  chunk_value <- getOption("bcdata.chunk_limit", default = bcdc_single_download_limit())
   chunk_limit <- getOption("bcdata.single_download_limit", default = bcdc_single_download_limit())
 
-  if (!is.null(chunk_value) && chunk_value >= chunk_limit) {
+  if (!is.null(chunk_value) && chunk_value > chunk_limit) {
     stop(glue::glue("Your chunk value of {chunk_value} exceed the BC Data Catalogue chunk limit of {chunk_limit}"), call. = FALSE)
   }
+  chunk_value
 }
 
 bcdc_get_capabilities <- function() {

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -12,28 +12,33 @@
 
 #' Retrieve options used in bcdata, their value if set and the default value.
 #'
-#' This function retrieves bcdata specific options that can be set. These options can be set
-#' using `option({name of the option} = {value of the option})`. The default options are purposefully
-#' set conservatively to hopefully ensure successful requests. Resetting these options may result in
-#' failed calls to the data catalogue. Options in R are reset every time R is re-started. See examples for
-#' addition ways to restore your initial state.
+#' This function retrieves bcdata specific options that can be set. These
+#' options can be set using `option({name of the option} = {value of the
+#' option})`. The default options are purposefully set conservatively to
+#' hopefully ensure successful requests. Resetting these options may result in
+#' failed calls to the data catalogue. Options in R are reset every time R is
+#' re-started. See examples for addition ways to restore your initial state.
 #'
-#' `bcdata.max_geom_pred_size` is the maximum size in bytes of an object used for a geometric operation. Objects
-#' that are bigger than this value will have a bounding box drawn and apply the geometric operation
-#' on that simpler polygon. The [bcdc_check_geom_size] function can be used to assess whether a given spatial object
-#' exceed the value of this option. Users can iteratively try to increase the maximum geometric predicate size and see
-#' if the bcdata catalogue accepts the request.
+#' `bcdata.max_geom_pred_size` is the maximum size in bytes of an object used
+#' for a geometric operation. Objects that are bigger than this value will have
+#' a bounding box drawn and apply the geometric operation on that simpler
+#' polygon. The [bcdc_check_geom_size] function can be used to assess whether a
+#' given spatial object exceed the value of this option. Users can iteratively
+#' try to increase the maximum geometric predicate size and see if the bcdata
+#' catalogue accepts the request.
 #'
-#' `bcdata.chunk_limit` is an option useful when dealing with very large data sets. When requesting large objects
-#' from the catalogue, the request is broken up into smaller chunks which are then recombined after they've
-#' been downloaded. This is called "pagination". bcdata does this all for you but using this option you can set the size of the chunk
-#' requested. On faster internet connections, a bigger chunk limit could be useful while on slower connections,
-#' it is advisable to lower the chunk limit. The default is the same as `bcdata.single_download_limit`.
+#' `bcdata.chunk_limit` is an option useful when dealing with very large data
+#' sets. When requesting large objects from the catalogue, the request is broken
+#' up into smaller chunks which are then recombined after they've been
+#' downloaded. This is called "pagination". bcdata does this all for you but
+#' using this option you can set the size of the chunk requested. On slower
+#' connections, or when having problems, it may help to lower the chunk limit.
 #'
-#' `bcdata.single_download_limit` is the maximum number of records an object can be before forcing a paginated download
-#' (see entry for `bcdata.chunk_limit` for details on pagination).
-#' Tweaking this option in conjunction with `bcdata.chunk_limit` can often resolve failures in large and complex downloads.
-#' The default is obtained from the server.
+#' `bcdata.single_download_limit` *Deprecated*. This is the maximum number of
+#' records an object can be before forcing a paginated download; it is set by
+#' querying the server capabilities. This option is deprecated and will be
+#' removed in a future release. Use `bcdata.chunk_limit` to set a lower value
+#' pagination value.
 #'
 #' @examples
 #' \donttest{
@@ -69,29 +74,29 @@ bcdc_options <- function() {
     ifelse(is.null(x), NA, as.numeric(x))
   }
 
-  single_download_limit <- bcdc_single_download_limit()
+  server_single_download_limit <- bcdc_single_download_limit()
 
   dplyr::tribble(
     ~ option, ~ value, ~default,
     "bcdata.max_geom_pred_size", null_to_na(getOption("bcdata.max_geom_pred_size")), 5E5,
-    "bcdata.chunk_limit", null_to_na(getOption("bcdata.chunk_limit")), single_download_limit,
+    "bcdata.chunk_limit", null_to_na(getOption("bcdata.chunk_limit")), server_single_download_limit,
     "bcdata.single_download_limit",
-    null_to_na(getOption("bcdata.single_download_limit")), single_download_limit
+    null_to_na(deprecate_single_download_limit_option()), server_single_download_limit
   )
 }
 
 
 check_chunk_limit <- function(){
-  chunk_value <- getOption("bcdata.chunk_limit")
-  chunk_limit <- getOption("bcdata.single_download_limit", default = bcdc_single_download_limit())
+  chunk_limit <- getOption("bcdata.chunk_limit")
+  single_download_limit <- deprecate_single_download_limit_option()
 
-  if (is.null(chunk_value)) {
-    return(chunk_limit)
+  if (is.null(chunk_limit)) {
+    return(single_download_limit)
   }
-  if (chunk_value > chunk_limit) {
-    stop(glue::glue("Your chunk value of {chunk_value} exceed the BC Data Catalogue chunk limit of {chunk_limit}"), call. = FALSE)
+  if (chunk_limit > single_download_limit) {
+    stop(glue::glue("Your chunk value of {chunk_limit} exceeds the BC Data Catalogue chunk limit of {single_download_limit}"), call. = FALSE)
   }
-  chunk_value
+  chunk_limit
 }
 
 bcdc_get_capabilities <- function() {
@@ -156,4 +161,21 @@ bcdc_single_download_limit <- function() {
   # Looking globally also works but is slower: ".//ows:Constraint[@name='CountDefault']"
   count_defaults <- xml2::xml_find_first(doc, count_default_xpath)
   xml2::xml_integer(count_defaults)
+}
+
+# Used to send a message once per session that the single_download_limit option
+# will be deprecated. When we remove it, replace all calls to this function
+# with bcdc_single_download_limit() and remove the ._bcdataenv_$single_download_limit_warned
+# object from .onLoad.
+deprecate_single_download_limit_option <- function() {
+  x <- getOption("bcdata.single_download_limit")
+  if (!is.null(x)) {
+    if (!isTRUE(._bcdataenv_$single_download_limit_warned)) {
+      warning("The bcdata.single_download_limit option is deprecated. Please use bcdata.chunk_limit instead.",
+              call. = FALSE)
+      assign("single_download_limit_warned", TRUE, envir = ._bcdataenv_)
+    }
+    return(x)
+  }
+  bcdc_single_download_limit()
 }

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -30,7 +30,7 @@
 #' `bcdata.chunk_limit` is an option useful when dealing with very large data
 #' sets. When requesting large objects from the catalogue, the request is broken
 #' up into smaller chunks which are then recombined after they've been
-#' downloaded. This is called "pagination". bcdata does this all for you but
+#' downloaded. This is called "pagination". bcdata does this all for you, however by
 #' using this option you can set the size of the chunk requested. On slower
 #' connections, or when having problems, it may help to lower the chunk limit.
 #'

--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -82,10 +82,13 @@ bcdc_options <- function() {
 
 
 check_chunk_limit <- function(){
-  chunk_value <- getOption("bcdata.chunk_limit", default = bcdc_single_download_limit())
+  chunk_value <- getOption("bcdata.chunk_limit")
   chunk_limit <- getOption("bcdata.single_download_limit", default = bcdc_single_download_limit())
 
-  if (!is.null(chunk_value) && chunk_value > chunk_limit) {
+  if (is.null(chunk_value)) {
+    return(chunk_limit)
+  }
+  if (chunk_value > chunk_limit) {
     stop(glue::glue("Your chunk value of {chunk_value} exceed the BC Data Catalogue chunk limit of {chunk_limit}"), call. = FALSE)
   }
   chunk_value

--- a/R/utils-classes.R
+++ b/R/utils-classes.R
@@ -71,7 +71,7 @@ print.bcdc_promise <- function(x, ...) {
 
   cat_bullet(strwrap(glue::glue("Using {col_blue('collect()')} on this object will return {col_green(number_of_records)} features ",
                         "and {col_green(fields)} fields")))
-  if (number_of_records > chunk_size) {
+  if (number_of_records > chunk_size) { # this triggers pagination
     cat_bullet(strwrap(glue::glue("Accessing this record requires pagination and will make {col_green(ceiling(number_of_records/chunk_size))} separate requests to the WFS. ",
                                               "See ?bcdc_options")))
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
 .onLoad <- function(...) {
   ._bcdataenv_$named_get_record_warned <- FALSE # nocov
   ._bcdataenv_$get_capabilities_xml <- NULL # nocov
-
+  ._bcdataenv_$single_download_limit_warned <- FALSE # nocov
 }
 
 # Define bcdc_sf as a subclass of sf so that it works

--- a/man/bcdc_options.Rd
+++ b/man/bcdc_options.Rd
@@ -11,21 +11,21 @@ This function retrieves bcdata specific options that can be set. These
 options can be set using \verb{option(\{name of the option\} = \{value of the option\})}. The default options are purposefully set conservatively to
 hopefully ensure successful requests. Resetting these options may result in
 failed calls to the data catalogue. Options in R are reset every time R is
-re-started. See examples for addition ways to restore your initial state.
+re-started. See examples for additional ways to restore your initial state.
 }
 \details{
 \code{bcdata.max_geom_pred_size} is the maximum size in bytes of an object used
 for a geometric operation. Objects that are bigger than this value will have
 a bounding box drawn and apply the geometric operation on that simpler
 polygon. The \link{bcdc_check_geom_size} function can be used to assess whether a
-given spatial object exceed the value of this option. Users can iteratively
+given spatial object exceeds the value of this option. Users can iteratively
 try to increase the maximum geometric predicate size and see if the bcdata
 catalogue accepts the request.
 
 \code{bcdata.chunk_limit} is an option useful when dealing with very large data
 sets. When requesting large objects from the catalogue, the request is broken
 up into smaller chunks which are then recombined after they've been
-downloaded. This is called "pagination". bcdata does this all for you but
+downloaded. This is called "pagination". bcdata does this all for you, however by
 using this option you can set the size of the chunk requested. On slower
 connections, or when having problems, it may help to lower the chunk limit.
 

--- a/man/bcdc_options.Rd
+++ b/man/bcdc_options.Rd
@@ -24,12 +24,12 @@ if the bcdata catalogue accepts the request.
 from the catalogue, the request is broken up into smaller chunks which are then recombined after they've
 been downloaded. This is called "pagination". bcdata does this all for you but using this option you can set the size of the chunk
 requested. On faster internet connections, a bigger chunk limit could be useful while on slower connections,
-it is advisable to lower the chunk limit. Chunks must be less than 10000.
+it is advisable to lower the chunk limit. The default is the same as \code{bcdata.single_download_limit}.
 
 \code{bcdata.single_download_limit} is the maximum number of records an object can be before forcing a paginated download
 (see entry for \code{bcdata.chunk_limit} for details on pagination).
 Tweaking this option in conjunction with \code{bcdata.chunk_limit} can often resolve failures in large and complex downloads.
-The default is 10000 records.
+The default is obtained from the server.
 }
 \examples{
 \donttest{

--- a/man/bcdc_options.Rd
+++ b/man/bcdc_options.Rd
@@ -7,29 +7,33 @@
 bcdc_options()
 }
 \description{
-This function retrieves bcdata specific options that can be set. These options can be set
-using \verb{option(\{name of the option\} = \{value of the option\})}. The default options are purposefully
-set conservatively to hopefully ensure successful requests. Resetting these options may result in
-failed calls to the data catalogue. Options in R are reset every time R is re-started. See examples for
-addition ways to restore your initial state.
+This function retrieves bcdata specific options that can be set. These
+options can be set using \verb{option(\{name of the option\} = \{value of the option\})}. The default options are purposefully set conservatively to
+hopefully ensure successful requests. Resetting these options may result in
+failed calls to the data catalogue. Options in R are reset every time R is
+re-started. See examples for addition ways to restore your initial state.
 }
 \details{
-\code{bcdata.max_geom_pred_size} is the maximum size in bytes of an object used for a geometric operation. Objects
-that are bigger than this value will have a bounding box drawn and apply the geometric operation
-on that simpler polygon. The \link{bcdc_check_geom_size} function can be used to assess whether a given spatial object
-exceed the value of this option. Users can iteratively try to increase the maximum geometric predicate size and see
-if the bcdata catalogue accepts the request.
+\code{bcdata.max_geom_pred_size} is the maximum size in bytes of an object used
+for a geometric operation. Objects that are bigger than this value will have
+a bounding box drawn and apply the geometric operation on that simpler
+polygon. The \link{bcdc_check_geom_size} function can be used to assess whether a
+given spatial object exceed the value of this option. Users can iteratively
+try to increase the maximum geometric predicate size and see if the bcdata
+catalogue accepts the request.
 
-\code{bcdata.chunk_limit} is an option useful when dealing with very large data sets. When requesting large objects
-from the catalogue, the request is broken up into smaller chunks which are then recombined after they've
-been downloaded. This is called "pagination". bcdata does this all for you but using this option you can set the size of the chunk
-requested. On faster internet connections, a bigger chunk limit could be useful while on slower connections,
-it is advisable to lower the chunk limit. The default is the same as \code{bcdata.single_download_limit}.
+\code{bcdata.chunk_limit} is an option useful when dealing with very large data
+sets. When requesting large objects from the catalogue, the request is broken
+up into smaller chunks which are then recombined after they've been
+downloaded. This is called "pagination". bcdata does this all for you but
+using this option you can set the size of the chunk requested. On slower
+connections, or when having problems, it may help to lower the chunk limit.
 
-\code{bcdata.single_download_limit} is the maximum number of records an object can be before forcing a paginated download
-(see entry for \code{bcdata.chunk_limit} for details on pagination).
-Tweaking this option in conjunction with \code{bcdata.chunk_limit} can often resolve failures in large and complex downloads.
-The default is obtained from the server.
+\code{bcdata.single_download_limit} \emph{Deprecated}. This is the maximum number of
+records an object can be before forcing a paginated download; it is set by
+querying the server capabilities. This option is deprecated and will be
+removed in a future release. Use \code{bcdata.chunk_limit} to set a lower value
+pagination value.
 }
 \examples{
 \donttest{

--- a/man/bcdc_query_geodata.Rd
+++ b/man/bcdc_query_geodata.Rd
@@ -32,8 +32,7 @@ Queries features from the B.C. Web Feature Service. See
 \code{"wms"} in the \code{format} column it is available as a Web
 Feature Service, and you can query and download it
 using \code{bcdc_query_geodata()}. The response will be
-paginated if the number of features is above the number
-set by the \code{bcdata.single_download_limit} option.
+paginated if the number of features is greater than that allowed by the server.
 Please see \code{\link[=bcdc_options]{bcdc_options()}} for defaults and more
 information.
 }

--- a/scratch/scratch_test_iterating.R
+++ b/scratch/scratch_test_iterating.R
@@ -22,6 +22,6 @@ for(nme in single_arg_functions[6]){
     filter(fun(local)) %>%
     collect()
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,17 +1,12 @@
-# Copyright 2019 Province of British Columbia
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and limitations under the License.
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
 
-if (require("testthat", quietly = TRUE)) {
-  library(bcdata)
-  library(sf)
-  test_check("bcdata")
-}
+library(testthat)
+library(bcdata)
+
+test_check("bcdata")

--- a/tests/testthat/_snaps/options.md
+++ b/tests/testthat/_snaps/options.md
@@ -1,0 +1,36 @@
+# bcdata.single_download_limit is deprecated but works
+
+    Code
+      bcdc_query_geodata(record = "76b1b7a3-2112-4444-857a-afccf7b20da8")
+    Condition
+      Warning:
+      The bcdata.single_download_limit option is deprecated. Please use bcdata.chunk_limit instead.
+    Output
+      Querying 'bc-airports' record
+      * Using collect() on this object will return 455 features and 41 fields
+      * Accessing this record requires pagination and will make 455 separate
+      * requests to the WFS. See ?bcdc_options
+      * At most six rows of the record are printed here
+      --------------------------------------------------------------------------------
+      Simple feature collection with 6 features and 41 fields
+      Geometry type: POINT
+      Dimension:     XY
+      Bounding box:  xmin: 833323.9 ymin: 381604.1 xmax: 1198292 ymax: 1054950
+      Projected CRS: NAD83 / BC Albers
+      # A tibble: 6 x 42
+        id        CUSTODIAN_ORG_DESCRI~1 BUSINESS_CATEGORY_CL~2 BUSINESS_CATEGORY_DE~3
+        <chr>     <chr>                  <chr>                  <chr>                 
+      1 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      2 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      3 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      4 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      5 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      6 WHSE_IMA~ "Ministry of Forest, ~ airTransportation      Air Transportation    
+      # i abbreviated names: 1: CUSTODIAN_ORG_DESCRIPTION,
+      #   2: BUSINESS_CATEGORY_CLASS, 3: BUSINESS_CATEGORY_DESCRIPTION
+      # i 38 more variables: OCCUPANT_TYPE_DESCRIPTION <chr>, SOURCE_DATA_ID <chr>,
+      #   SUPPLIED_SOURCE_ID_IND <chr>, AIRPORT_NAME <chr>, DESCRIPTION <chr>,
+      #   PHYSICAL_ADDRESS <chr>, ALIAS_ADDRESS <chr>, STREET_ADDRESS <chr>,
+      #   POSTAL_CODE <chr>, LOCALITY <chr>, CONTACT_PHONE <chr>,
+      #   CONTACT_EMAIL <chr>, CONTACT_FAX <chr>, WEBSITE_URL <chr>, ...
+

--- a/tests/testthat/test-bcdc-get-citation.R
+++ b/tests/testthat/test-bcdc-get-citation.R
@@ -10,9 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("Testing bcdc_get_citation function")
-
-
 test_that("bcdc_get_citation take a character and returns a bibentry",{
   skip_if_net_down()
   skip_on_cran()

--- a/tests/testthat/test-browse.R
+++ b/tests/testthat/test-browse.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("confirm browsing ability")
-
 test_that("bcdc_browse returns the correct url", {
   skip_if_net_down()
   skip_on_cran()

--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("Testing ability to create CQL strings")
 suppressPackageStartupMessages(library(sf, quietly = TRUE))
 
 the_geom <- st_sf(st_sfc(st_point(c(1,1))))
@@ -26,7 +25,7 @@ test_that("bcdc_cql_string fails when used on an uncollected (promise) object", 
 })
 
 test_that("CQL function works", {
-  expect_is(CQL("SELECT * FROM foo;"), c("CQL", "SQL"))
+  expect_s3_class(CQL("SELECT * FROM foo;"), c("CQL", "SQL"))
 })
 
 test_that("All cql geom predicate functions work", {

--- a/tests/testthat/test-describe-feature.R
+++ b/tests/testthat/test-describe-feature.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("Testing bcdc_describe_feature function")
-
 test_that("Test that bcdc_describe feature returns the correct columns",{
   skip_on_cran()
   skip_if_net_down()

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -1,5 +1,3 @@
-context("Edge cases and catalogue peculiarities")
-
 test_that("recods with wms but inconsistent layer_name, object_name fields work", {
   skip_if_net_down()
   skip_on_cran()
@@ -7,13 +5,13 @@ test_that("recods with wms but inconsistent layer_name, object_name fields work"
   # layer_name = RSLT_PLANTING_ALL_RSLT_CF
   # object_name = WHSE_FOREST_VEGETATION.RSLT_PLANTING_SVW
   # wms uses object_name
-  expect_is(bcdc_query_geodata("results-planting"), "bcdc_promise")
+  expect_s3_class(bcdc_query_geodata("results-planting"), "bcdc_promise")
 
   # https://github.com/bcgov/bcdata/issues/129
   # layer_name = WHSE_ADMIN_BOUNDARIES.ADM_NR_DISTRICTS_SPG
   # wms uses layer_name (generalized)
   expect_message(
-    expect_is(bcdc_query_geodata("natural-resource-nr-district"), "bcdc_promise"),
+    expect_s3_class(bcdc_query_geodata("natural-resource-nr-district"), "bcdc_promise"),
     "You are accessing a simplified view of the data"
   )
 })

--- a/tests/testthat/test-geom-operators.R
+++ b/tests/testthat/test-geom-operators.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("Geometric operators work with appropriate data")
-
 if (has_internet() && identical(Sys.getenv("NOT_CRAN"), "true")) {
   local <- bcdc_query_geodata("regional-districts-legally-defined-administrative-areas-of-bc") %>%
     filter(ADMIN_AREA_NAME == "Cariboo Regional District") %>%
@@ -23,7 +21,7 @@ test_that("bcdc_check_geom_size outputs message with low threshold",{
   skip_if_net_down()
 
   withr::local_options(list(bcdata.max_geom_pred_size = 1))
-  expect_message(bcdc_check_geom_size(local))
+  expect_message(bcdc_check_geom_size(local), "The object is too large")
   expect_false(bcdc_check_geom_size(local))
 })
 
@@ -46,7 +44,7 @@ test_that("WITHIN works",{
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -61,7 +59,7 @@ test_that("INTERSECTS works",{
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 
 })
@@ -77,7 +75,7 @@ test_that("RELATE works", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -91,7 +89,7 @@ test_that("DWITHIN works", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -107,7 +105,7 @@ test_that("BEYOND works", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -121,7 +119,7 @@ test_that("BBOX works with an sf bbox", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -136,7 +134,7 @@ test_that("BBOX works with an sf object", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })
 
@@ -150,6 +148,6 @@ test_that("Other predicates work with an sf bbox", {
       collect()
   )
 
-  expect_is(remote, "sf")
+  expect_s3_class(remote, "sf")
   expect_equal(attr(remote, "sf_column"), "geometry")
 })

--- a/tests/testthat/test-get-data.R
+++ b/tests/testthat/test-get-data.R
@@ -10,14 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing ability of bcdc_get_data to retrieve a valid object")
-
 test_that("bcdc_get_data collects an sf object for a valid record and resource id", {
   skip_if_net_down()
   skip_on_cran()
   bc_airports <- bcdc_get_data('76b1b7a3-2112-4444-857a-afccf7b20da8',
                                resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c")
-  expect_is(bc_airports, "sf")
+  expect_s3_class(bc_airports, "sf")
   expect_equal(attr(bc_airports, "sf_column"), "geometry")
 })
 
@@ -25,15 +23,15 @@ test_that("bcdc_get_data collects an sf object for a valid record and resource i
 test_that("bcdc_get_data works with slug and full url with corresponding resource", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(ret1 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
+  expect_s3_class(ret1 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
             "sf")
-  expect_is(ret2 <- bcdc_get_data("bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
+  expect_s3_class(ret2 <- bcdc_get_data("bc-airports", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
             "sf")
-  expect_is(ret3 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
+  expect_s3_class(ret3 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
             "sf")
-  expect_is(ret4 <- bcdc_get_data("76b1b7a3-2112-4444-857a-afccf7b20da8", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
+  expect_s3_class(ret4 <- bcdc_get_data("76b1b7a3-2112-4444-857a-afccf7b20da8", resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"),
             "sf")
-  expect_is(ret5 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8/resource/4d0377d9-e8a1-429b-824f-0ce8f363512c"),
+  expect_s3_class(ret5 <- bcdc_get_data("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8/resource/4d0377d9-e8a1-429b-824f-0ce8f363512c"),
             "sf")
 
   for (x in list(ret2, ret3, ret4, ret5)) {
@@ -47,7 +45,7 @@ test_that("bcdc_get_data works with a non-wms record with only one resource",{
   skip_if_net_down()
   skip_on_cran()
   name <- "ee9d4ee0-6a34-4dff-89e0-9add9a969168" # "criminal-code-traffic-offences"
-  expect_is(bcdc_get_data(name), "tbl")
+  expect_s3_class(bcdc_get_data(name), "tbl")
 })
 
 test_that("bcdc_get_data works when using read_excel arguments", {
@@ -56,31 +54,31 @@ test_that("bcdc_get_data works when using read_excel arguments", {
   ret <- bcdc_get_data("2e469ff2-dadb-45ea-af9d-f5683a4b9465",
                        resource = "18510a60-de82-440a-b806-06fba70eaf9d",
                        skip = 4, n_max = 3)
-  expect_is(ret, "tbl")
-  expect_equivalent(nrow(ret), 3L)
+  expect_s3_class(ret, "tbl")
+  expect_equal(nrow(ret), 3L, ignore_attr = TRUE)
 })
 
 test_that("bcdc_get_data works with an xls when specifying a specific resource",{
   skip_if_net_down()
   skip_on_cran()
   name <- 'bc-grizzly-bear-habitat-classification-and-rating'
-  expect_is(bcdc_get_data(name, resource = '7b09f82f-e7d0-44bf-9310-b94039b323a8'), "tbl")
+  expect_s3_class(bcdc_get_data(name, resource = '7b09f82f-e7d0-44bf-9310-b94039b323a8'), "tbl")
 })
 
 test_that("bcdc_get_data will return non-wms resources",{
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
+  expect_s3_class(bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8',
                  resource = 'fcccba36-b528-4731-8978-940b3cc04f69'), "tbl")
 
-  expect_is(bcdc_get_data(record = 'fa542137-a976-49a6-856d-f1201adb2243',
+  expect_s3_class(bcdc_get_data(record = 'fa542137-a976-49a6-856d-f1201adb2243',
                           resource = 'dc1098a7-a4b8-49a3-adee-9badd4429279'), "tbl")
 })
 
 test_that("bcdc_get_data works with a zipped shp file", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data(record = '481d6d4d-a536-4df9-9e9c-7473cd2ed89e',
+  expect_s3_class(bcdc_get_data(record = '481d6d4d-a536-4df9-9e9c-7473cd2ed89e',
                           resource = '41c9bff0-4e25-49fc-a3e2-2a2e426ac71d'),
             "sf")
 })
@@ -88,7 +86,7 @@ test_that("bcdc_get_data works with a zipped shp file", {
 test_that("unknown single file (shp) inside zip", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data("e31f7488-27fa-4330-ae86-160a0deb8a59"),
+  expect_s3_class(bcdc_get_data("e31f7488-27fa-4330-ae86-160a0deb8a59"),
             "sf")
 })
 
@@ -122,7 +120,7 @@ test_that("fails informatively when can't read a file", {
 test_that("bcdc_get_data can return the wms resource when it is specified by resource",{
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data('76b1b7a3-2112-4444-857a-afccf7b20da8',
+  expect_s3_class(bcdc_get_data('76b1b7a3-2112-4444-857a-afccf7b20da8',
                           resource = "4d0377d9-e8a1-429b-824f-0ce8f363512c"), "sf")
 })
 
@@ -130,17 +128,17 @@ test_that("bcdc_get_data can return the wms resource when it is specified by res
 test_that("a wms record with only one resource works with only the record id",{
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data("bc-college-region-boundaries"), "sf")
+  expect_s3_class(bcdc_get_data("bc-college-region-boundaries"), "sf")
   })
 
 test_that("bcdc_get_data works with a bcdc_record object", {
   skip_if_net_down()
   skip_on_cran()
   record <- bcdc_get_record("bc-college-region-boundaries")
-  expect_is(bcdc_get_data(record), "sf")
+  expect_s3_class(bcdc_get_data(record), "sf")
 
   record <- bcdc_get_record('fa542137-a976-49a6-856d-f1201adb2243')
-  expect_is(bcdc_get_data(record,
+  expect_s3_class(bcdc_get_data(record,
                           resource = 'dc1098a7-a4b8-49a3-adee-9badd4429279'),
             "tbl")
 })
@@ -155,7 +153,7 @@ test_that("bcdc_get_data fails with invalid input", {
 test_that("bcdc_get_data works with BCGW name", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW"), "bcdc_sf")
+  expect_s3_class(bcdc_get_data("WHSE_IMAGERY_AND_BASE_MAPS.GSR_AIRPORTS_SVW"), "bcdc_sf")
 })
 
 test_that("bcdc_get_data fails when no downloadable resources", {
@@ -177,8 +175,7 @@ test_that("bcdc_get_data handles sheet name specification", {
   skip_on_cran()
   expect_message(bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6'), 'This .xlsx resource contains the following sheets:')
   expect_error(bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = "foo"), "Error: Sheet 'foo' not found")
-  out <- capture.output(bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = "Notes"), type = 'message')
-  expect_false(any(grepl('This .xlsx resource contains the following sheets:', out)))
+  expect_s3_class(bcdc_get_data('8620ce82-4943-43c4-9932-40730a0255d6', sheet = "Multi Unit Homes"), "data.frame")
 })
 
 test_that("bcdc_get_data returns a list object when resource has a json extension", {

--- a/tests/testthat/test-get_record.R
+++ b/tests/testthat/test-get_record.R
@@ -10,18 +10,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("test-get_record")
-
 test_that("bcdc_get_record works with slug and full url", {
   skip_on_cran()
   skip_if_net_down()
-  expect_is(ret1 <- bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports"),
+  expect_s3_class(ret1 <- bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/bc-airports"),
            "bcdc_record")
-  expect_is(ret2 <- bcdc_get_record("bc-airports"),
+  expect_s3_class(ret2 <- bcdc_get_record("bc-airports"),
            "bcdc_record")
-  expect_is(ret3 <- bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8"),
+  expect_s3_class(ret3 <- bcdc_get_record("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8"),
            "bcdc_record")
-  expect_is(ret4 <- bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8"),
+  expect_s3_class(ret4 <- bcdc_get_record("76b1b7a3-2112-4444-857a-afccf7b20da8"),
            "bcdc_record")
   expect_equal(ret1$title, "BC Airports")
   lapply(list(ret2, ret3, ret4), expect_equal, ret1)
@@ -75,15 +73,15 @@ test_that("bcdc_list works", {
   skip_on_cran()
   skip_if_net_down()
   ret <- bcdc_list()
-  expect_is(ret, "character")
+  expect_type(ret, "character")
   expect_gt(length(ret), 1000)
 })
 
 test_that("bcdc_search works", {
   skip_on_cran()
   skip_if_net_down()
-  expect_is(bcdc_search("forest"), "bcdc_recordlist")
-  expect_is(bcdc_search("regional district", res_format = "fgdb"),
+  expect_s3_class(bcdc_search("forest"), "bcdc_recordlist")
+  expect_s3_class(bcdc_search("regional district", res_format = "fgdb"),
             "bcdc_recordlist")
   expect_error(bcdc_search(organization = "foo"),
                "foo is not a valid value for organization")
@@ -139,7 +137,7 @@ test_that("bcdc_get_record works with/without authentication", {
   # record NOT requiring auth
   expect_message(res <- bcdc_get_record(point_record),
                  "Authorizing with your stored API key")
-  expect_is(res, "bcdc_record")
+  expect_s3_class(res, "bcdc_record")
 
   # record requiring auth
   auth_record_id <- Sys.getenv("BCDC_TEST_RECORD")
@@ -147,7 +145,7 @@ test_that("bcdc_get_record works with/without authentication", {
 
   expect_message(res <- bcdc_get_record(auth_record_id),
                  "Authorizing with your stored API key")
-  expect_is(res, "bcdc_record")
+  expect_s3_class(res, "bcdc_record")
 
   Sys.unsetenv("BCDC_KEY")
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -34,6 +34,7 @@ test_that("bcdata.single_download_limit is deprecated but works", {
   skip_if_net_down()
   skip_on_cran()
   withr::local_options(list(bcdata.single_download_limit = 1))
+  withr::local_envvar(list(BCDC_KEY = NULL)) # so snapshot not affected by message
   expect_snapshot(
     bcdc_query_geodata(record = '76b1b7a3-2112-4444-857a-afccf7b20da8')
   )

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing options")
-
 test_that("bcdc_options() returns a tibble",{
   skip_if_net_down()
   skip_on_cran()
@@ -32,14 +30,12 @@ test_that("bcdata.chunk_limit",{
   })
 })
 
-test_that("bcdata.single_download_limit", {
+test_that("bcdata.single_download_limit is deprecated but works", {
   skip_if_net_down()
   skip_on_cran()
   withr::local_options(list(bcdata.single_download_limit = 1))
-  expect_message(
-    bcdc_get_data(record = '76b1b7a3-2112-4444-857a-afccf7b20da8', resource =
-                    '4d0377d9-e8a1-429b-824f-0ce8f363512c'),
-    "paginated"
+  expect_snapshot(
+    bcdc_query_geodata(record = '76b1b7a3-2112-4444-857a-afccf7b20da8')
   )
 })
 

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -31,6 +31,7 @@ test_that("bcdata.chunk_limit",{
 })
 
 test_that("bcdata.single_download_limit is deprecated but works", {
+  # This can be removed when bcdata.single_download_limit is removed
   skip_if_net_down()
   skip_on_cran()
   withr::local_options(list(bcdata.single_download_limit = 1))
@@ -41,6 +42,7 @@ test_that("bcdata.single_download_limit is deprecated but works", {
 })
 
 test_that("bcdata.single_download_limit can be changed",{
+  # This can be removed when bcdata.single_download_limit is removed
   skip_if_net_down()
   skip_on_cran()
   withr::local_options(list(bcdata.single_download_limit = 13))

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -23,8 +23,13 @@ test_that("bcdc_options() returns a tibble",{
 test_that("bcdata.chunk_limit",{
   skip_if_net_down()
   skip_on_cran()
-  withr::local_options(list(bcdata.chunk_limit = 10000))
-  expect_error(check_chunk_limit())
+  withr::with_options(list(bcdata.chunk_limit = 100000), {
+    expect_error(check_chunk_limit())
+  })
+  withr::with_options(list(bcdata.chunk_limit = 10), {
+    expect_silent(check_chunk_limit())
+    expect_equal(check_chunk_limit(), 10)
+  })
 })
 
 test_that("bcdata.single_download_limit", {
@@ -36,7 +41,6 @@ test_that("bcdata.single_download_limit", {
                     '4d0377d9-e8a1-429b-824f-0ce8f363512c'),
     "paginated"
   )
-
 })
 
 test_that("bcdata.single_download_limit can be changed",{

--- a/tests/testthat/test-print-methods.R
+++ b/tests/testthat/test-print-methods.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testprint methods")
-
 test_that("bcdc_promise print methods work",{
   skip_on_cran()
   skip_if_net_down()
@@ -37,7 +35,7 @@ test_that("show query works for bcdc_promise object",{
   skip_on_cran()
   skip_if_net_down()
   prom_obj <- bcdc_query_geodata('76b1b7a3-2112-4444-857a-afccf7b20da8')
-  expect_is(show_query(prom_obj), "bcdc_query")
+  expect_s3_class(show_query(prom_obj), "bcdc_query")
 })
 
 
@@ -45,7 +43,7 @@ test_that("show query works for bcdc_sf object",{
   skip_on_cran()
   skip_if_net_down()
   sf_obj <- collect(bcdc_query_geodata('76b1b7a3-2112-4444-857a-afccf7b20da8'))
-  expect_is(show_query(sf_obj), "bcdc_query")
+  expect_s3_class(show_query(sf_obj), "bcdc_query")
 })
 
 test_that("record with a zip file prints correctly", {

--- a/tests/testthat/test-query-geodata-base-methods.R
+++ b/tests/testthat/test-query-geodata-base-methods.R
@@ -1,13 +1,10 @@
-context("test base methods")
-
-
 
 test_that("head works", {
   skip_if_net_down()
   skip_on_cran()
   promise <- bcdc_query_geodata(point_record) %>%
     head()
-  expect_is(promise, "bcdc_promise")
+  expect_s3_class(promise, "bcdc_promise")
   collected <- collect(promise)
   expect_equal(nrow(collected), 6L)
   d2 <- bcdc_query_geodata(point_record) %>%
@@ -27,7 +24,7 @@ test_that("tail works", {
   skip_on_cran()
   promise <- bcdc_query_geodata(point_record) %>%
     tail()
-  expect_is(promise, "bcdc_promise")
+  expect_s3_class(promise, "bcdc_promise")
   collected <- collect(promise)
   expect_equal(nrow(collected), 6L)
   d2 <- bcdc_query_geodata(point_record) %>%

--- a/tests/testthat/test-query-geodata-collect.R
+++ b/tests/testthat/test-query-geodata-collect.R
@@ -10,13 +10,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing ability of bcdc_query_geodata to retrieve for bcdc using collect")
-
 test_that("bcdc_query_geodata collects an sf object for a valid id", {
   skip_on_cran()
   skip_if_net_down()
   bc_airports <- bcdc_query_geodata("bc-airports") %>% collect()
-  expect_is(bc_airports, "sf")
+  expect_s3_class(bc_airports, "sf")
   expect_equal(attr(bc_airports, "sf_column"), "geometry")
 })
 
@@ -24,7 +22,7 @@ test_that("bcdc_query_geodata collects using as_tibble", {
   skip_on_cran()
   skip_if_net_down()
   bc_airports <- bcdc_query_geodata("bc-airports") %>% as_tibble()
-  expect_is(bc_airports, "sf")
+  expect_s3_class(bc_airports, "sf")
   expect_equal(attr(bc_airports, "sf_column"), "geometry")
 })
 
@@ -32,7 +30,7 @@ test_that("bcdc_query_geodata succeeds with a records over 10000 rows",{
   skip_on_cran()
   skip_if_net_down()
   skip("Skipping the BEC test, though available for testing")
-  expect_is(collect(bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")),
+  expect_s3_class(collect(bcdc_query_geodata("terrestrial-protected-areas-representation-by-biogeoclimatic-unit")),
             "bcdc_sf")
 })
 
@@ -40,16 +38,16 @@ test_that("bcdc_query_geodata succeeds with a records over 10000 rows",{
 test_that("bcdc_query_geodata works with slug and full url using collect", {
   skip_on_cran()
   skip_if_net_down()
-  expect_is(ret1 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/bc-airports") %>% collect(),
+  expect_s3_class(ret1 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/bc-airports") %>% collect(),
             "sf")
-  expect_is(ret2 <- bcdc_query_geodata("bc-airports") %>% collect(),
+  expect_s3_class(ret2 <- bcdc_query_geodata("bc-airports") %>% collect(),
             "sf")
-  expect_is(ret3 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
+  expect_s3_class(ret3 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8")
             %>% collect(),
             "sf")
-  expect_is(ret4 <- bcdc_query_geodata("76b1b7a3-2112-4444-857a-afccf7b20da8") %>% collect(),
+  expect_s3_class(ret4 <- bcdc_query_geodata("76b1b7a3-2112-4444-857a-afccf7b20da8") %>% collect(),
             "sf")
-  expect_is(ret5 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8/resource/4d0377d9-e8a1-429b-824f-0ce8f363512c")
+  expect_s3_class(ret5 <- bcdc_query_geodata("https://catalogue.data.gov.bc.ca/dataset/76b1b7a3-2112-4444-857a-afccf7b20da8/resource/4d0377d9-e8a1-429b-824f-0ce8f363512c")
             %>% collect(),
             "sf")
 
@@ -74,7 +72,7 @@ test_that("bcdc_query_geodata works with spatial data that have SHAPE for the ge
       filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) %>%
       collect()
   )
-  expect_is(ret1, "sf")
+  expect_s3_class(ret1, "sf")
 })
 
 test_that("collect() returns a bcdc_sf object",{
@@ -100,5 +98,5 @@ test_that("bcdc_sf objects has attributes",{
                      "url", "full_url", "time_downloaded"))
   expect_true(nzchar(attributes(sf_obj)$url))
   expect_true(nzchar(attributes(sf_obj)$full_url))
-  expect_is(attributes(sf_obj)$time_downloaded, "POSIXt")
+  expect_s3_class(attributes(sf_obj)$time_downloaded, "POSIXt")
 })

--- a/tests/testthat/test-query-geodata-filter.R
+++ b/tests/testthat/test-query-geodata-filter.R
@@ -9,8 +9,6 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-
-context("testing ability of filter methods to narrow a wfs query")
 library(sf, quietly = TRUE)
 
 test_that("bcdc_query_geodata accepts R expressions to refine data call",{
@@ -19,7 +17,7 @@ test_that("bcdc_query_geodata accepts R expressions to refine data call",{
   one_feature <- bcdc_query_geodata(point_record) %>%
     filter(SOURCE_DATA_ID == '455') %>%
     collect()
-  expect_is(one_feature, "sf")
+  expect_s3_class(one_feature, "sf")
   expect_equal(attr(one_feature, "sf_column"), "geometry")
   expect_equal(nrow(one_feature), 1)
 })
@@ -30,7 +28,7 @@ test_that("bcdc_query_geodata accepts R expressions to refine data call",{
   one_feature <- bcdc_query_geodata(point_record) %>%
     filter(SOURCE_DATA_ID == '455') %>%
     collect()
-  expect_is(one_feature, "sf")
+  expect_s3_class(one_feature, "sf")
   expect_equal(attr(one_feature, "sf_column"), "geometry")
   expect_equal(nrow(one_feature), 1)
 })
@@ -48,7 +46,7 @@ test_that("operators work with different remote geom col names",{
   em_program <- bcdc_query_geodata("employment-program-of-british-columbia-regional-boundaries") %>%
     filter(INTERSECTS(crd)) %>%
     collect()
-  expect_is(em_program, "sf")
+  expect_s3_class(em_program, "sf")
   expect_equal(attr(em_program, "sf_column"), "geometry")
 
   ## REMOTE "SHAPE"
@@ -57,7 +55,7 @@ test_that("operators work with different remote geom col names",{
       filter(FIRE_YEAR == 2000, FIRE_CAUSE == "Person", INTERSECTS(crd)) %>%
       collect()
   )
-  expect_is(crd_fires, "sf")
+  expect_s3_class(crd_fires, "sf")
   expect_equal(attr(crd_fires, "sf_column"), "geometry")
 
 })
@@ -143,7 +141,7 @@ test_that("large vectors supplied to filter succeeds",{
     filter(WATERSHED_GROUP_CODE %in% "PORI") %>%
     collect()
 
-  expect_is(bcdc_query_geodata(lines_record) %>%
+  expect_s3_class(bcdc_query_geodata(lines_record) %>%
     filter(WATERSHED_KEY %in% pori$WATERSHED_KEY),
     "bcdc_promise")
 
@@ -220,7 +218,7 @@ test_that("an intersect with an object less than 5E5 proceeds",{
     st_as_sfc()
 
 
-  expect_is(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
+  expect_s3_class(parks <- bcdc_query_geodata(record = "6a2fea1b-0cc4-4fc2-8017-eaf755d516da") %>%
     filter(WITHIN(small_districts)) %>%
     collect(),
     "bcdc_sf")
@@ -282,21 +280,21 @@ test_that("Nesting functions inside a CQL geometry predicate works (#146)", {
 test_that("works with dates", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(bcdc_query_geodata('historical-orders-and-alerts') %>%
+  expect_s3_class(bcdc_query_geodata('historical-orders-and-alerts') %>%
               filter(EVENT_START_DATE < "2017-05-01") %>%
               collect(), "bcdc_sf")
-  expect_is(bcdc_query_geodata('historical-orders-and-alerts') %>%
+  expect_s3_class(bcdc_query_geodata('historical-orders-and-alerts') %>%
               filter(EVENT_START_DATE < as.Date("2017-05-01")) %>%
               collect(), "bcdc_sf")
-  expect_is(bcdc_query_geodata('historical-orders-and-alerts') %>%
+  expect_s3_class(bcdc_query_geodata('historical-orders-and-alerts') %>%
               filter(EVENT_START_DATE < as.POSIXct("2017-05-01")) %>%
               collect(), "bcdc_sf")
   dt <- as.Date("2017-05-01")
-  expect_is(bcdc_query_geodata('historical-orders-and-alerts') %>%
+  expect_s3_class(bcdc_query_geodata('historical-orders-and-alerts') %>%
               filter(EVENT_START_DATE < dt) %>%
               collect(), "bcdc_sf")
   pt <- as.Date("2017-05-01")
-  expect_is(bcdc_query_geodata('historical-orders-and-alerts') %>%
+  expect_s3_class(bcdc_query_geodata('historical-orders-and-alerts') %>%
               filter(EVENT_START_DATE < pt) %>%
               collect(), "bcdc_sf")
 })
@@ -304,12 +302,12 @@ test_that("works with dates", {
 test_that("works with various as.x functions", {
   skip_if_net_down()
   skip_on_cran()
-  expect_is(
+  expect_s3_class(
     bcdc_query_geodata(point_record) %>%
       filter(NUMBER_OF_RUNWAYS == as.numeric("3")) %>%
       collect(),
     "bcdc_sf")
-  expect_is(
+  expect_s3_class(
     bcdc_query_geodata(point_record) %>%
       filter(DESCRIPTION == as.character("seaplane anchorage")) %>%
       collect(),

--- a/tests/testthat/test-query-geodata-mutate.R
+++ b/tests/testthat/test-query-geodata-mutate.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing that mutate method fails")
-
 test_that("mutate fails on a bcdata promise object",{
   skip_on_cran()
   skip_if_net_down()

--- a/tests/testthat/test-query-geodata-select.R
+++ b/tests/testthat/test-query-geodata-select.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing ability of select methods to narrow a wfs query")
-
 test_that("select doesn't remove the geometry column",{
   skip_if_net_down()
   skip_on_cran()
@@ -68,15 +66,15 @@ test_that("select accept dplyr like column specifications",{
 
 
   ## Most basic select
-  expect_is(select(layer, ADMIN_AREA_NAME, OIC_MO_YEAR), "bcdc_promise")
+  expect_s3_class(select(layer, ADMIN_AREA_NAME, OIC_MO_YEAR), "bcdc_promise")
   ## Using a pre-assigned vector
-  expect_is(select(layer, all_of(correct_fields)), "bcdc_promise")
+  expect_s3_class(select(layer, all_of(correct_fields)), "bcdc_promise")
   ## Throws an error when column doesn't exist
   expect_error(select(layer, all_of(wrong_fields)))
-  expect_is(select(layer, ADMIN_AREA_NAME:OIC_MO_YEAR), "bcdc_promise")
+  expect_s3_class(select(layer, ADMIN_AREA_NAME:OIC_MO_YEAR), "bcdc_promise")
   ## Some weird mix
-  expect_is(select(layer, 'ADMIN_AREA_NAME', OIC_MO_YEAR), "bcdc_promise")
+  expect_s3_class(select(layer, 'ADMIN_AREA_NAME', OIC_MO_YEAR), "bcdc_promise")
   ## Another weird mix
-  expect_is(select(layer, c('ADMIN_AREA_NAME','OIC_MO_YEAR') , OIC_MO_NUMBER), "bcdc_promise")
-  expect_is(select(layer, 1:5), "bcdc_promise")
+  expect_s3_class(select(layer, c('ADMIN_AREA_NAME','OIC_MO_YEAR') , OIC_MO_NUMBER), "bcdc_promise")
+  expect_s3_class(select(layer, 1:5), "bcdc_promise")
 })

--- a/tests/testthat/test-query-geodata.R
+++ b/tests/testthat/test-query-geodata.R
@@ -10,14 +10,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("testing the output of bcdc_query_geodata")
-
 test_that("bcdc_query_geodata returns an bcdc_promise object for a valid id OR bcdc_record", {
   skip_on_cran()
   skip_if_net_down()
   # id (character)
   bc_airports <- bcdc_query_geodata("bc-airports")
-  expect_is(bc_airports, "bcdc_promise")
+  expect_s3_class(bc_airports, "bcdc_promise")
 
   # bcdc_record
   bc_airports_record <- bcdc_get_record("bc-airports")
@@ -33,10 +31,10 @@ test_that("bcdc_query_geodata returns an object with a query, a cli, the catalog
   skip_if_net_down()
   skip_on_cran()
   bc_airports <- bcdc_query_geodata("bc-airports")
-  expect_is(bc_airports[["query_list"]], "list")
-  expect_is(bc_airports[["cli"]], "HttpClient")
-  expect_is(bc_airports[["record"]], "bcdc_record")
-  expect_is(bc_airports[["cols_df"]], "data.frame")
+  expect_type(bc_airports[["query_list"]], "list")
+  expect_s3_class(bc_airports[["cli"]], "HttpClient")
+  expect_s3_class(bc_airports[["record"]], "bcdc_record")
+  expect_s3_class(bc_airports[["cols_df"]], "data.frame")
 })
 
 
@@ -45,7 +43,7 @@ test_that("bcdc_query_geodata returns an object with bcdc_promise class when usi
   skip_if_net_down()
   bc_eml <- bcdc_query_geodata("bc-environmental-monitoring-locations") %>%
     filter(PERMIT_RELATIONSHIP == "DISCHARGE")
-  expect_is(bc_eml, "bcdc_promise")
+  expect_s3_class(bc_eml, "bcdc_promise")
 })
 
 
@@ -53,7 +51,7 @@ test_that("bcdc_query_geodata returns an object with bcdc_promise class on recor
   skip_on_cran()
   skip_if_net_down()
   airports <- bcdc_query_geodata("bc-airports")
-  expect_is(airports, "bcdc_promise")
+  expect_s3_class(airports, "bcdc_promise")
 })
 
 test_that("bcdc_query_geodata fails when >1 record", {

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -10,29 +10,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context('test bcdc_search')
-
-
-test_that('bcdc_search works', {
-  skip_on_cran()
-  skip_if_net_down()
-  output_path <- tempfile()
-  suppressWarnings(
-    verify_output(output_path, {
-      bcdc_search("Container", n = 5)
-    })
-  )
-  expect_false(any(grepl("Error", readLines(output_path))))
-})
-
 test_that('bcdc_search subsetting works', {
   skip_on_cran()
   skip_if_net_down()
   rec_list <- bcdc_search("Container", n = 5)
-  expect_is(rec_list, "bcdc_recordlist")
+  expect_s3_class(rec_list, "bcdc_recordlist")
   expect_length(rec_list, 5)
   shorter <- rec_list[3:5]
-  expect_is(shorter, "bcdc_recordlist")
+  expect_s3_class(shorter, "bcdc_recordlist")
   expect_length(shorter, 3)
 })
 
@@ -47,7 +32,7 @@ test_that("bcdc_search works with zero results", {
   skip_if_net_down()
 
   res <- bcdc_search("foobarbananas")
-  expect_is(res, "bcdc_recordlist")
+  expect_s3_class(res, "bcdc_recordlist")
   expect_length(res, 0L)
 
   expect_output(print(res), "returned no results")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,8 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-context("test-utils")
-
 test_that("check_geom_col_names works", {
   col_df_list <- lapply(gml_types(), function(x) {
     data.frame(col_name = "SHAPE", remote_col_type = x)
@@ -19,7 +17,7 @@ test_that("check_geom_col_names works", {
   lapply(col_df_list, function(x) {
     new_query <- specify_geom_name(x, "DWITHIN({geom_col}, foobar)")
     expect_equal(as.character(new_query), "DWITHIN(SHAPE, foobar)")
-    expect_is(new_query, "sql")
+    expect_s3_class(new_query, "sql")
   })
 })
 
@@ -68,7 +66,7 @@ test_that("bcdc_get_capabilities works", {
   )
 
   ._bcdataenv_$get_capabilities_xml <- NULL
-  expect_is(bcdc_get_capabilities(), "xml_document")
+  expect_s3_class(bcdc_get_capabilities(), "xml_document")
   expect_equal(bcdc_get_capabilities(), ._bcdataenv_$get_capabilities_xml)
 })
 
@@ -82,6 +80,6 @@ test_that("make_url works", {
 test_that("names_to_lazy_tbl works", {
   nms <- letters[1:3]
   lazy <- names_to_lazy_tbl(nms)
-  expect_is(lazy, "tbl_lazy")
+  expect_s3_class(lazy, "tbl_lazy")
   expect_equal(lazy$lazy_query$vars, nms)
 })


### PR DESCRIPTION
#330 surfaced the change to the single download limit on the WFS server to 500 records (down from 10,000). This exposed the potential incompatibility between `bcdcd.single_download_limit` and `bcdc.chunk_limit` options, where it was possible for the latter to be larger than the former. Since `bcdcd.single_download_limit` determined whether or not we needed pagination for a request, and `bcdc.chunk_limit` is used to determined the page size (number of records requested in a page), we were getting into the situation where we were attempting to retrieve more records in a page than is allowed by the server.

This PR sets the default chunk limit to the `bcdc.single_download_limit` by default, and also checks more comprehensively that the two values are compatible.

This address part of #330, but unfortunately does not fix all of it.