### PR TITLE
No longer need http for getCapabilities request. #329

### DIFF
--- a/R/bcdc_options.R
+++ b/R/bcdc_options.R
@@ -107,14 +107,14 @@ bcdc_get_capabilities <- function() {
   }
 
   if (has_internet()) {
-    url <- make_url(bcdc_web_service_host(https = FALSE), "geo/pub/ows")
+    url <- make_url(bcdc_web_service_host(), "geo/pub/ows")
     cli <- bcdc_http_client(url, auth = FALSE)
 
 
     cc <- try(cli$get(query = list(
       SERVICE = "WFS",
       VERSION = "2.0.0",
-      REQUEST = "Getcapabilities"
+      REQUEST = "GetCapabilities"
     )), silent = TRUE)
 
     if (inherits(cc, "try-error")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,13 +28,8 @@ wms_base_url <- function(host = bcdc_web_service_host()) {
   make_url(host, "geo/pub/wms")
 }
 
-bcdc_web_service_host <- function(https = TRUE) {
-  host <- getOption("bcdata.web_service_host",
-            default = "https://openmaps.gov.bc.ca")
-  if (!https) {
-    return(gsub("^https", "http", host))
-  }
-  host
+bcdc_web_service_host <- function() {
+  getOption("bcdata.web_service_host", default = "https://openmaps.gov.bc.ca")
 }
 
 bcdata_user_agent <- function(){


### PR DESCRIPTION
DSS fixed the ows GetCapabilities endpoint (https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=2.0.0&request=GetCapabilities) so we no longer need to switch to http for this one call. 

Closes #329 