### PR TITLE
added example of partial query using %like% and %in%

### DIFF
--- a/R/bcdc-web-services.R
+++ b/R/bcdc-web-services.R
@@ -57,16 +57,22 @@
 #'
 #' # To query based on partial matches, use %LIKE%:
 #' try(
-#'   bcdc_query_geodata("bc-airports") %>%
-#'   filter(PHYSICAL_ADDRESS %LIKE% 'Vict%')
-#')
+#'   res <- bcdc_query_geodata("bc-airports") %>%
+#'     filter(PHYSICAL_ADDRESS %LIKE% 'Vict%')
+#' )
+#' 
 #' # To query using %IN%
 #' try(
-#'   bcdc_query_geodata("bc-airports") %>%
-#'   filter(AIRPORT_NAME %IN% c("Victoria Harbour (Camel Point) Heliport",
-#'                              "Victoria Harbour (Shoal Point) Heliport")) %>%
-#'   collect()
-#')
+#'   res <- bcdc_query_geodata("bc-airports") %>%
+#'     filter(
+#'       AIRPORT_NAME %IN%
+#'         c(
+#'           "Victoria Harbour (Camel Point) Heliport",
+#'           "Victoria Harbour (Shoal Point) Heliport"
+#'         )
+#'     ) %>%
+#'     collect()
+#' )
 #'
 #'
 #' try(

--- a/R/bcdc-web-services.R
+++ b/R/bcdc-web-services.R
@@ -55,6 +55,20 @@
 #'     collect()
 #' )
 #'
+#' # To query based on partial matches, use %LIKE%:
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'   filter(PHYSICAL_ADDRESS %LIKE% 'Vict%')
+#')
+#' # To query using %IN%
+#' try(
+#'   bcdc_query_geodata("bc-airports") %>%
+#'   filter(AIRPORT_NAME %IN% c("Victoria Harbour (Camel Point) Heliport",
+#'                              "Victoria Harbour (Shoal Point) Heliport")) %>%
+#'   collect()
+#')
+#'
+#'
 #' try(
 #'   res <- bcdc_query_geodata("groundwater-wells") %>%
 #'     filter(OBSERVATION_WELL_NUMBER == "108") %>%

--- a/man/bcdc_query_geodata.Rd
+++ b/man/bcdc_query_geodata.Rd
@@ -60,6 +60,26 @@ try(
     collect()
 )
 
+# To query based on partial matches, use \%LIKE\%:
+try(
+  res <- bcdc_query_geodata("bc-airports") \%>\%
+    filter(PHYSICAL_ADDRESS \%LIKE\% 'Vict\%')
+)
+
+# To query using \%IN\%
+try(
+  res <- bcdc_query_geodata("bc-airports") \%>\%
+    filter(
+      AIRPORT_NAME \%IN\%
+        c(
+          "Victoria Harbour (Camel Point) Heliport",
+          "Victoria Harbour (Shoal Point) Heliport"
+        )
+    ) \%>\%
+    collect()
+)
+
+
 try(
   res <- bcdc_query_geodata("groundwater-wells") \%>\%
     filter(OBSERVATION_WELL_NUMBER == "108") \%>\%


### PR DESCRIPTION
In response to #355 and #227 

May not solve the integration  of `CQL()` or `str_*` or `grep` but these new examples that use `%LIKE%` and `%IN%` will be useful for a number of use cases. 