### PR TITLE
fix missing parens to fix R CMD check error on R-devel

### DIFF
--- a/tests/testthat/test-cql-string.R
+++ b/tests/testthat/test-cql-string.R
@@ -20,8 +20,10 @@ test_that("bcdc_cql_string fails when an invalid arguments are given",{
 })
 
 test_that("bcdc_cql_string fails when used on an uncollected (promise) object", {
-  expect_error(bcdc_cql_string(structure(list, class = "bcdc_promise")),
-               "you need to use collect")
+  expect_error(
+    bcdc_cql_string(structure(list(), class = "bcdc_promise")),
+    "you need to use collect"
+  )
 })
 
 test_that("CQL function works", {


### PR DESCRIPTION
This small typo is leading to a CRAN check error in R devel due to modifying attributes of a primitive function: https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/bcdata-00check.html.

```
    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Error ('test-cql-string.R:23:3'): bcdc_cql_string fails when used on an uncollected (promise) object ──
    Error in `attributes(.Data) <- c(attributes(.Data), attrib)`: Cannot modify attributes on primitive functions
    Backtrace:
        ▆
     1. ├─testthat::expect_error(...) at test-cql-string.R:23:3
     2. │ └─testthat:::expect_condition_matching(...)
     3. │   └─testthat:::quasi_capture(...)
     4. │     ├─testthat (local) .capture(...)
     5. │     │ └─base::withCallingHandlers(...)
     6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
     7. ├─bcdata:::bcdc_cql_string(structure(list, class = "bcdc_promise"))
     8. └─base::structure(list, class = "bcdc_promise")
```

Possibly the smallest change ever required for a new release